### PR TITLE
Fix wrong numbering of headings 

### DIFF
--- a/_sec_cascode_stage.qmd
+++ b/_sec_cascode_stage.qmd
@@ -65,5 +65,5 @@ Setting $G_\mathrm{D} = 0$ (an open) results in $g_\mathrm{in} = 0$ as well, so 
 However, setting $G_\mathrm{D} = \infty$ (a short or low-ohmic impedance) results in the well-known result of $g_\mathrm{in} = \gm + \gds \approx \gm$, which means that the input impedance looking into a cascode is approximately $1/\gm$. 
 
 ::: {.callout-important title="Benefit of Cascode (Input)"}
-This has the practical benefit that a capacitance connected at this noise results in a high-frequency pole, which is often not critical in terms of stability. Further, the voltage swing at a cascode input node is small due to the often small impedance, and this minimizes the Miller effect at connected inter-node capacitors (see @sec-miller-theorem).
+This has the practical benefit that a capacitance connected at this node results in a high-frequency pole, which is often not critical in terms of stability. Further, the voltage swing at a cascode input node is small due to the often small impedance, and this minimizes the Miller effect at connected inter-node capacitors (see @sec-miller-theorem).
 :::

--- a/_sec_improved_ota.qmd
+++ b/_sec_improved_ota.qmd
@@ -8,7 +8,13 @@ The transistor name appendix "C" indicates a cascode device sitting atop its bas
 It is critically import for a stable performance across PVT that the bias voltages for the cascode gates are created in a manner that tracks variations with process, temperature, and supply voltage!
 :::
 
-The current mirrors constructed out of $M_\mathrm{5/5C,6/6C}$ and $M_\mathrm{3/3C,4/4C}$ are a special kind of **cascoded current mirror for low-voltage operation**. This type is very often used, as it forces the $\VGS$ and $\VDS$ of $M_{5,6}$ (and $M_{3,4}$) to be equal, so the current mirror ratio is independent of $\gds$. Further, by properly selecting the bias voltages of the cascode a low-voltage operation is achieved as $\VDS$ can be minimized, allowing even triode operation of the current-mirror MOSFETs (as, noted above, a large $\gds$ is not a big issue).
+The current mirrors constructed out of $M_\mathrm{5/5C,6/6C}$ and $M_\mathrm{3/3C,4/4C}$ are a special kind of **cascoded current mirror for low-voltage operation**, also referred to as high-swing cascoded current mirror [@Jespers_Murmann_2017]. This type is very often used, as it forces the $\VGS$ and $\VDS$ of $M_{5,6}$ (and $M_{3,4}$) to be equal, so the current mirror ratio is independent of $\gds$. 
+
+::: {.callout-tip title="Exercise: Cascoded Current Mirror vs. High-Swing Cascoded Current Mirror"}
+Try to verify the above statement of equal drain-source voltages by deriving both, an equation for $\VDS[5]$ assuming a high-swing cascoded current mirror (@fig-improved-ota) and $\VDS[5]$ in case of a simple cascoded current mirror, where the reference branch $(M_\mathrm{6/6C})$ is comprised of two mosfet diodes.
+:::
+
+Further, by properly selecting the bias voltages of the cascode a low-voltage operation is achieved as $\VDS$ can be minimized, allowing even triode operation of the current-mirror MOSFETs (as, noted above, a large $\gds$ is not a big issue).
 
 A simplified small-signal gain calculation of this improved OTA uses the result of @eq-simple-ota-gain-dc and @eq-cs-cascode-output-impedance to arrive at the approximate dc gain of
 $$

--- a/cace/_docs/ota-5t_schematic.md
+++ b/cace/_docs/ota-5t_schematic.md
@@ -1,5 +1,5 @@
 
-# CACE Summary for ota-5t
+# CACE Summary for ota-5t {.unnumbered .unlisted}
 
 **netlist source**: schematic
 
@@ -11,68 +11,68 @@
 | Settling time        | ngspice              | tsettle              |             any |   0.135 us |          any |   0.142 us |        10 us |   0.155 us |   Pass ✅    |
 
 
-## Plots
+## Plots {.unnumbered .unlisted}
 
-## gain_vs_temp
+## gain_vs_temp {.unnumbered .unlisted}
 
 ![gain_vs_temp](./cace/_docs/ota-5t/schematic/gain_vs_temp.png)
 
-## gain_vs_vin
+## gain_vs_vin {.unnumbered .unlisted}
 
 ![gain_vs_vin](./cace/_docs/ota-5t/schematic/gain_vs_vin.png)
 
-## gain_vs_vdd
+## gain_vs_vdd {.unnumbered .unlisted}
 
 ![gain_vs_vdd](./cace/_docs/ota-5t/schematic/gain_vs_vdd.png)
 
-## gain_vs_corner
+## gain_vs_corner {.unnumbered .unlisted}
 
 ![gain_vs_corner](./cace/_docs/ota-5t/schematic/gain_vs_corner.png)
 
-## bw_vs_temp
+## bw_vs_temp {.unnumbered .unlisted}
 
 ![bw_vs_temp](./cace/_docs/ota-5t/schematic/bw_vs_temp.png)
 
-## bw_vs_vin
+## bw_vs_vin {.unnumbered .unlisted}
 
 ![bw_vs_vin](./cace/_docs/ota-5t/schematic/bw_vs_vin.png)
 
-## bw_vs_vdd
+## bw_vs_vdd {.unnumbered .unlisted}
 
 ![bw_vs_vdd](./cace/_docs/ota-5t/schematic/bw_vs_vdd.png)
 
-## bw_vs_corner
+## bw_vs_corner {.unnumbered .unlisted}
 
 ![bw_vs_corner](./cace/_docs/ota-5t/schematic/bw_vs_corner.png)
 
-## noise_vs_temp
+## noise_vs_temp {.unnumbered .unlisted}
 
 ![noise_vs_temp](./cace/_docs/ota-5t/schematic/noise_vs_temp.png)
 
-## noise_vs_vin
+## noise_vs_vin {.unnumbered .unlisted}
 
 ![noise_vs_vin](./cace/_docs/ota-5t/schematic/noise_vs_vin.png)
 
-## noise_vs_vdd
+## noise_vs_vdd {.unnumbered .unlisted}
 
 ![noise_vs_vdd](./cace/_docs/ota-5t/schematic/noise_vs_vdd.png)
 
-## noise_vs_corner
+## noise_vs_corner {.unnumbered .unlisted}
 
 ![noise_vs_corner](./cace/_docs/ota-5t/schematic/noise_vs_corner.png)
 
-## settling_vs_temp
+## settling_vs_temp {.unnumbered .unlisted}
 
 ![settling_vs_temp](./cace/_docs/ota-5t/schematic/settling_vs_temp.png)
 
-## settling_vs_vin
+## settling_vs_vin {.unnumbered .unlisted}
 
 ![settling_vs_vin](./cace/_docs/ota-5t/schematic/settling_vs_vin.png)
 
-## settling_vs_vdd
+## settling_vs_vdd {.unnumbered .unlisted}
 
 ![settling_vs_vdd](./cace/_docs/ota-5t/schematic/settling_vs_vdd.png)
 
-## settling_vs_corner
+## settling_vs_corner {.unnumbered .unlisted}
 
 ![settling_vs_corner](./cace/_docs/ota-5t/schematic/settling_vs_corner.png)

--- a/cace/_docs/ota-improved_schematic.md
+++ b/cace/_docs/ota-improved_schematic.md
@@ -1,5 +1,5 @@
 
-# CACE Summary for ota-improved
+# CACE Summary for ota-improved {.unnumbered .unlisted}
 
 **netlist source**: schematic
 
@@ -11,68 +11,68 @@
 | Settling time        | ngspice              | tsettle              |             any |   0.196 us |          any |   0.212 us |         5 us |   0.226 us |   Pass ✅    |
 
 
-## Plots
+## Plots {.unnumbered .unlisted}
 
-## gain_vs_temp
+## gain_vs_temp {.unnumbered .unlisted}
 
 ![gain_vs_temp](./cace/_docs/ota-improved/schematic/gain_vs_temp.png)
 
-## gain_vs_vin
+## gain_vs_vin {.unnumbered .unlisted}
 
 ![gain_vs_vin](./cace/_docs/ota-improved/schematic/gain_vs_vin.png)
 
-## gain_vs_vdd
+## gain_vs_vdd {.unnumbered .unlisted}
 
 ![gain_vs_vdd](./cace/_docs/ota-improved/schematic/gain_vs_vdd.png)
 
-## gain_vs_corner
+## gain_vs_corner {.unnumbered .unlisted}
 
 ![gain_vs_corner](./cace/_docs/ota-improved/schematic/gain_vs_corner.png)
 
-## bw_vs_temp
+## bw_vs_temp {.unnumbered .unlisted}
 
 ![bw_vs_temp](./cace/_docs/ota-improved/schematic/bw_vs_temp.png)
 
-## bw_vs_vin
+## bw_vs_vin {.unnumbered .unlisted}
 
 ![bw_vs_vin](./cace/_docs/ota-improved/schematic/bw_vs_vin.png)
 
-## bw_vs_vdd
+## bw_vs_vdd {.unnumbered .unlisted}
 
 ![bw_vs_vdd](./cace/_docs/ota-improved/schematic/bw_vs_vdd.png)
 
-## bw_vs_corner
+## bw_vs_corner {.unnumbered .unlisted}
 
 ![bw_vs_corner](./cace/_docs/ota-improved/schematic/bw_vs_corner.png)
 
-## noise_vs_temp
+## noise_vs_temp {.unnumbered .unlisted}
 
 ![noise_vs_temp](./cace/_docs/ota-improved/schematic/noise_vs_temp.png)
 
-## noise_vs_vin
+## noise_vs_vin {.unnumbered .unlisted}
 
 ![noise_vs_vin](./cace/_docs/ota-improved/schematic/noise_vs_vin.png)
 
-## noise_vs_vdd
+## noise_vs_vdd {.unnumbered .unlisted}
 
 ![noise_vs_vdd](./cace/_docs/ota-improved/schematic/noise_vs_vdd.png)
 
-## noise_vs_corner
+## noise_vs_corner {.unnumbered .unlisted}
 
 ![noise_vs_corner](./cace/_docs/ota-improved/schematic/noise_vs_corner.png)
 
-## settling_vs_temp
+## settling_vs_temp {.unnumbered .unlisted}
 
 ![settling_vs_temp](./cace/_docs/ota-improved/schematic/settling_vs_temp.png)
 
-## settling_vs_vin
+## settling_vs_vin {.unnumbered .unlisted}
 
 ![settling_vs_vin](./cace/_docs/ota-improved/schematic/settling_vs_vin.png)
 
-## settling_vs_vdd
+## settling_vs_vdd {.unnumbered .unlisted}
 
 ![settling_vs_vdd](./cace/_docs/ota-improved/schematic/settling_vs_vdd.png)
 
-## settling_vs_corner
+## settling_vs_corner {.unnumbered .unlisted}
 
 ![settling_vs_corner](./cace/_docs/ota-improved/schematic/settling_vs_corner.png)

--- a/cace/fix_report_md_ota-5t.sh
+++ b/cace/fix_report_md_ota-5t.sh
@@ -3,6 +3,9 @@ FILE=_docs/ota-5t_schematic.md
 cp $FILE $FILE.tmp
 # fix paths for Quarto rendering
 sed 's#/ota#/cace/_docs/ota#g' $FILE.tmp > $FILE
+cp $FILE $FILE.tmp
+# suppress numbering and listing of headings
+sed '/^#/ s/$/ {.unnumbered .unlisted}' $FILE.tmp > $FILE
 # cp $FILE $FILE.tmp
 # remove Unicode for Latex rendering
 # iconv -c -f utf-8 -t ascii $FILE.tmp > $FILE

--- a/cace/fix_report_md_ota-improved.sh
+++ b/cace/fix_report_md_ota-improved.sh
@@ -3,6 +3,9 @@ FILE=_docs/ota-improved_schematic.md
 cp $FILE $FILE.tmp
 # fix paths for Quarto rendering
 sed 's#/ota#/cace/_docs/ota#g' $FILE.tmp > $FILE
+cp $FILE $FILE.tmp
+# suppress numbering and listing of headings
+sed '/^#/ s/$/ {.unnumbered .unlisted}' $FILE.tmp > $FILE
 # cp $FILE $FILE.tmp
 # remove Unicode for Latex rendering
 # iconv -c -f utf-8 -t ascii $FILE.tmp > $FILE

--- a/sizing/sizing_basic_ota.ipynb
+++ b/sizing/sizing_basic_ota.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Sizing for Basic 5T-OTA \n",
+    "# Sizing for Basic 5T-OTA {.unnumbered .unlisted}\n",
     "\n",
     "**Copyright 2024 Harald Pretl**\n",
     "\n",

--- a/sizing/sizing_basic_ota_improved.ipynb
+++ b/sizing/sizing_basic_ota_improved.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Sizing for Basic (Improved) OTA \n",
+    "# Sizing for Basic (Improved) OTA {.unnumbered .unlisted}\n",
     "\n",
     "**Copyright 2024 Harald Pretl**\n",
     "\n",


### PR DESCRIPTION
Markdown headings in external files such as notebooks or CACE reports should be ignored to have a consistent structure

Other: typos and minor additions to latest chapters