### PR TITLE
More Xschem shortcuts and updated definition of transit frequency

### DIFF
--- a/_app_xschem_cheatsheet.qmd
+++ b/_app_xschem_cheatsheet.qmd
@@ -4,7 +4,8 @@ When opening Xschem, using `Help -> Keys` a pop-up windows comes up with many us
 
 - `Cursor keys` to move around
 - `Ctrl-e` to go back to parent schematic
-- `e` to descend into selected symbol
+- `e` to descend into schematic of selected symbol
+- `i` to descend into symbol of selected symbol
 - `f` full zoom on schematic
 - `Shift-z` to zoom in
 - `Ctrl-z` to zoom out
@@ -18,7 +19,9 @@ When opening Xschem, using `Help -> Keys` a pop-up windows comes up with many us
 - `c` to copy elements
 - `Alt-Shift-l` to add wire label
 - `Alt-l` to add label pin
-- `m` move selected objects
+- `m` to move selected objects
+- `Shift-R` to rotate selected objects
+- `Shift-F` to mirror / flip selected objects
 - `q` to edit properties
 - `Ctrl-s` to save schematic
 - `t` to place a text
@@ -27,6 +30,7 @@ When opening Xschem, using `Help -> Keys` a pop-up windows comes up with many us
 - `w` to draw a wire
 - `Shift-W` draw wire and snap to close pin or net point
 - `&` to join, break, and collapse wires
+- `A` to make symbol from schematic
 
 #### Viewing/Simulating Schematics
 
@@ -35,3 +39,5 @@ When opening Xschem, using `Help -> Keys` a pop-up windows comes up with many us
 - `Shift-K` to unhighlight all nets
 - `Shift-o` to toggle light/dark color scheme
 - `s` to run a simulation
+- `a & b` to add cursors to an in-circuit simulation graph
+- `f` full zoom on y- or x-axis in in-circuit simulation graph

--- a/_sec_basic_ota.qmd
+++ b/_sec_basic_ota.qmd
@@ -20,7 +20,7 @@ In order to design an OTA we need an application, and from this we need to deriv
 
 {{< include figures/_fig_voltage_buffer_ota.qmd >}}
 
-If the voltage gain of the OTA is @fig-voltage-buffer-ota is high, then $V_\mathrm{out} \approx V_\mathrm{in}$. We now want to design an OTA for this application for the following specification values (see @tbl-voltage-buffer-spec). These values are rather typical of what could be expected for such a buffer design.
+If the voltage gain of the OTA in @fig-voltage-buffer-ota is high, then $V_\mathrm{out} \approx V_\mathrm{in}$. We now want to design an OTA for this application for the following specification values (see @tbl-voltage-buffer-spec). These values are rather typical of what could be expected for such a buffer design.
 
 | Specification                                           | Value                              | Unit    |
 |:--------------------------------------------------------|:----------------------------------:|:-------:|

--- a/_sec_first_steps.qmd
+++ b/_sec_first_steps.qmd
@@ -119,7 +119,7 @@ When the drain-source voltage $\VDS$ is increased, at some point the drain-sourc
 As you can see in the large-signal investigations, these transitions happen gradually, and it is difficult to define a precise point where one operating mode switches to the other one. In this sense we use terms like "triode" and "saturation" only in an approximate sense.
 :::
 
-A metric which is useful to assess the speed of a MOSFET is the so-called **transit frequency** $f_\mathrm{T}$. It is defined as the frequency where the current gain (output current divided by the input current) of a MOSFET driven by a voltage-source at the input and loaded by a voltage source at the output. It can easily be derived using the simplified MOSFET small-signal model of @fig-mosfet-small-signal-model-simplified by driving it with a voltage source and shorting the output to (neglecting the feed-forward current introduced by $\Cgd$)
+A metric which is useful to assess the speed of a MOSFET is the so-called **transit frequency** $f_\mathrm{T}$. It is defined as the frequency where the small-signal current gain (output current divided by the input current) of a MOSFET driven by a voltage-source at the input and loaded by a voltage source at the output drops to unity (reaches one). It can easily be derived using the simplified MOSFET small-signal model of @fig-mosfet-small-signal-model-simplified by driving it with a voltage source and shorting the output to (neglecting the feed-forward current introduced by $\Cgd$)
 $$
 \omega_\mathrm{T} = 2 \pi f_\mathrm{T} \approx \frac{\gm}{\Cgg} = \frac{\gm}{\Cgs + \Cgd + \Cgb}.
 $$ {#eq-mosfet-transit-frequency}


### PR DESCRIPTION
added further Xschem shortcuts and updated the definition of the transit frequency ("drops to unity / reaches one" was missing)