### PR TITLE
Lecture notes 26.11.2024

### DIFF
--- a/content/_sec_mosfet_diode.qmd
+++ b/content/_sec_mosfet_diode.qmd
@@ -158,7 +158,7 @@ The question is now how to simulate this open-loop gain, i.e., how to break the 
 
 There is an alternative method which breaks the loop open only by adding an ac voltage source in series (thus keeps the dc operating point intact), or injects current using an ac current source. Based on both measurements the open-loop gain can be calculated. This is called **Middlebrook's method** [@Middlebrook_1975] and is based on double injection, and we will use it for our loop simulations. This method is detailed in @sec-middlebrook-method.
 
-There are several other methods like Tian's method [@Tian_2001] for example. A comprehensive overview can be found in [@loop_gain_analysis] which describes ten different simulation-based loop gain analysis methods.
+There are several other methods like Tian's method [@Tian_2001] for example. A comprehensive overview can be found in [@Neag_2015] which describes ten different simulation-based loop gain analysis methods.
 
 We now want to simulate the open-loop transfer function $H_\mathrm{ol}(s)$ by using Middlebrook's method and confirm our analysis above.
 

--- a/content/_sec_mosfet_diode.qmd
+++ b/content/_sec_mosfet_diode.qmd
@@ -100,26 +100,26 @@ which is pretty much the transit frequency of the MOSFET!
 
 ## MOSFET Diode Stability Analysis
 
-::: {.callout-note title="Open-loop gain, closed-loop gain and loop-gain - A short recap"}
+::: {.callout-note title="Open-Loop Gain, Closed-Loop Gain, and Loop-Gain---A Short Recap"}
 @fig-feedback-system shows a negative feedback system with input $X(s)$ and output $Y(s)$, where $H_\mathrm{ol}(s)$ is the transfer function of the feed-forward path (also called **open-loop gain**) and $G(s)$ is the transfer function of the feedback network. The **loop-gain** is the product of both transfer functions $T(s) = H_\mathrm{ol}(s) G(s)$ and is used for the stability analysis. The closed-loop gain is defined as $H_\mathrm{cl}(s) = Y(s) / X(s)$ can be derived with $Y(s) = H_\mathrm{ol}(s) [X(s) - Y(s) G(s)]$ to be
 $$
 H_\mathrm{cl}(s) = \frac{Y(s)}{X(s)} = \frac{H_\mathrm{ol}(s)}{1 + H_\mathrm{ol}(s) G(s)} = \frac{H_\mathrm{ol}(s)}{1 + T(s)}
 $${#eq-closed-loop-gain}
 
-If the open-loop gain is really large $H_\mathrm{ol}(s) \gg 1$, then the closed-loop gain simplifies to $H_\mathrm{cl}(s) \approx 1 / G(s)$. This result is convenient, since it is independent of $H_\mathrm{ol}(s)$. Therefore, the overall gain is only set with the feedback gain $G(s)$ in operational amplifier circuits.
+If the open-loop gain is sufficiently large $H_\mathrm{ol}(s) \gg 1$, then the closed-loop gain simplifies to $H_\mathrm{cl}(s) \approx 1 / G(s)$. This result is convenient, since it is independent of $H_\mathrm{ol}(s)$. Therefore, the overall gain is only set with the feedback gain $G(s)$ in operational amplifier circuits.
 
 In the case of the MOSFET diode, $G(s) = 1$ and therefore $T(s) = H_\mathrm{ol}(s)$ and $H_\mathrm{cl}(s) \approx 1$. Therefore, this chapter uses open-loop gain and loop-gain as synonyms.
-:::
 
 {{< include ./figures/_fig_feedback_system.qmd >}}
+:::
 
-::: {.callout-note title="Gain-bandwidth product in feedback systems"}
-The gain-bandwidth product (GBP or GBWP) or transit frequency $f_\mathrm{T}$ of a first-order open-loop system is the product of the open-loop DC gain $H_\mathrm{ol,DC} = H_\mathrm{ol}(f = 0\,\text{Hz})$ and the open-loop $-3\,\text{dB}$ cut-off frequency $f_\mathrm{c,ol}$ of $H_\mathrm{ol}(s)$.
+::: {.callout-note title="Gain-Bandwidth Product in Feedback Systems"}
+The gain-bandwidth product (GBP or GBWP) or transit frequency $f_\mathrm{T}$ of a first-order open-loop system is the product of the open-loop dc gain $H_\mathrm{ol,dc} = H_\mathrm{ol}(f = 0\,\text{Hz})$ and the open-loop $-3\,\text{dB}$ cut-off frequency $f_\mathrm{c,ol}$ of $H_\mathrm{ol}(s)$.
 $$
-\text{GBWP} = f_\mathrm{T,ol} = H_\mathrm{ol,DC} f_\mathrm{c,ol}
+\text{GBWP} = f_\mathrm{T,ol} = H_\mathrm{ol,dc} f_\mathrm{c,ol}
 $$
 
-If a frequency-independent negative feedback $G$ (e.g. resistor divider) is applied to this open-loop system, the transit frequency changes to
+If a frequency-independent negative feedback $G$ (e.g., a resistive divider) is applied to this open-loop system, the transit frequency changes to
 $$
 f_\mathrm{T,cl} = f_\mathrm{T,ol} \sqrt{1 - G^2}
 $$
@@ -158,7 +158,7 @@ The question is now how to simulate this open-loop gain, i.e., how to break the 
 
 There is an alternative method which breaks the loop open only by adding an ac voltage source in series (thus keeps the dc operating point intact), or injects current using an ac current source. Based on both measurements the open-loop gain can be calculated. This is called **Middlebrook's method** [@Middlebrook_1975] and is based on double injection, and we will use it for our loop simulations. This method is detailed in @sec-middlebrook-method.
 
-There are several other methods like Tian's method [@Tian_2001] for example. A comprehensive overview can be found in [@Neag_2015] which describes ten different simulation-based loop gain analysis methods.
+There are several other methods like Tian's method [@Tian_2001], for example. A comprehensive overview can be found in [@Neag_2015] which describes ten different simulation-based loop gain analysis methods.
 
 We now want to simulate the open-loop transfer function $H_\mathrm{ol}(s)$ by using Middlebrook's method and confirm our analysis above.
 
@@ -172,10 +172,10 @@ If you are getting stuck you can look at this Xschem [testbench](./xschem/mosfet
 
 From simulation we see that the open-loop gain is $24.9\,\text{dB}$ at low frequencies, which matches quite well our prediction of $26.4\,\text{dB}$. In the Bode plot we see a low-pass with a $-3\,\text{dB}$ corner frequency of $1.4\,\text{GHz}$, which again is fairly close to our prediction of $1.1\,\text{GHz}$. 
 
-::: {.callout-important title="What about large-signal stability?"}
+::: {.callout-important title="What About Large-Signal Stability?"}
 Keep in mind that the above simulation only verifies the small-signal stability in one certain operating point. If we later look at the stability of an OTA it might be a good idea to verify the small-signal stability in different operating points.
 
-Furthermore, one can apply a step response to the closed-loop system input and estimate the phase margin from the overshoot and the output (see "Automatic Control" lecture). One could also use a step-wise step response to simulate different operating points for a certain time (see "Introduction in Integrated Circuit Design" lecture).
+Furthermore, one can apply a step response to the closed-loop system input and estimate the phase margin from the overshoot and the output (see *"Automatic Control"* lecture). One could also use a step-wise step response to simulate different operating points for a certain time (see *"Introduction in Integrated Circuit Design"* lecture).
 :::
 
 ## MOSFET Diode Noise Calculation
@@ -237,15 +237,15 @@ $$
 V_\mathrm{n,rms}^2 = \frac{k T}{C} 
 $$
 which is independent of $R$! This is a surprising result, and is the well-known $kT/C$ noise. 
-Intuitively, we could argue that the noise increases with larger $R$ but at the same time, the bandwidth decreases and therefore $R$ does not add additional noise.
+Intuitively, we could argue that the noise increases with larger $R$, but at the same time, the bandwidth decreases and therefore $R$ does not add additional noise.
 
 Side note: The shortest derivation of this formula involves the [equipartition theorem](https://en.wikipedia.org/wiki/Equipartition_theorem): Any system in thermal equilibrium has an energy of $kT/2$ per degree of freedom. This $RC$ system has one degree of freedom in the capacitor, and the stored energy in the capacitor is $CV_\mathrm{rms}^2/2$. Equating both energies we find that $V_\mathrm{rms}^2 = kT/C$.
 :::
 
 Calculating the rms noise voltage for our MOSFET diode we get $\sqrt{V_\mathrm{n,rms}^2} = \sqrt{1.38 \cdot 10^{-23} \cdot 300 \cdot 0.84 / 1.4 \cdot 10^{-15}} = 1.58\,\text{mV}$, which is a sizeable value! We run circuits in this technology at $\VDD = 1.5\,\mathrm{V}$, which leaves us with a signal swing of ca. $1.1\,\mathrm{V_{pp}}$ (single-ended), resulting in a dynamic range in this case of $20 \log_{10} (0.39 / 1.58 \cdot 10^{-3}) \approx 48\,\text{dB}$ assuming a sinusoidal signal.
 
-::: {.callout-important title="Be careful with parasitic capacitances in IC design"}
-In general, in integrated circuit design, we often have small parasitic capacitances on many different nodes that could sum up to unwanted high noise according to @eq-mosfet-diode-noise-rms-simplified.
+::: {.callout-important title="Be Careful with Parasitic Capacitances in IC Design"}
+In general, in integrated circuit design, we often have only small parasitic capacitances on many nodes that could sum up to unwanted high noise according to @eq-mosfet-diode-noise-rms-simplified. If one wants to lower the noise an increased capacitance could limit the bandwidth (and thus the $kT/C$ noise).
 :::
 
 ::: {.callout-important title="Large Bandwidth and Noise"}

--- a/content/_sec_mosfet_diode.qmd
+++ b/content/_sec_mosfet_diode.qmd
@@ -100,6 +100,39 @@ which is pretty much the transit frequency of the MOSFET!
 
 ## MOSFET Diode Stability Analysis
 
+::: {.callout-note title="Open-loop gain, closed-loop gain and loop-gain - A short recap"}
+@fig-feedback-system shows a negative feedback system with input $X(s)$ and output $Y(s)$, where $H_\mathrm{ol}(s)$ is the transfer function of the feed-forward path (also called **open-loop gain**) and $G(s)$ is the transfer function of the feedback network. The **loop-gain** is the product of both transfer functions $T(s) = H_\mathrm{ol}(s) G(s)$ and is used for the stability analysis. The closed-loop gain is defined as $H_\mathrm{cl}(s) = Y(s) / X(s)$ can be derived with $Y(s) = H_\mathrm{ol}(s) [X(s) - Y(s) G(s)]$ to be
+$$
+H_\mathrm{cl}(s) = \frac{Y(s)}{X(s)} = \frac{H_\mathrm{ol}(s)}{1 + H_\mathrm{ol}(s) G(s)} = \frac{H_\mathrm{ol}(s)}{1 + T(s)}
+$${#eq-closed-loop-gain}
+
+If the open-loop gain is really large $H_\mathrm{ol}(s) \gg 1$, then the closed-loop gain simplifies to $H_\mathrm{cl}(s) \approx 1 / G(s)$. This result is convenient, since it is independent of $H_\mathrm{ol}(s)$. Therefore, the overall gain is only set with the feedback gain $G(s)$ in operational amplifier circuits.
+
+In the case of the MOSFET diode, $G(s) = 1$ and therefore $T(s) = H_\mathrm{ol}(s)$ and $H_\mathrm{cl}(s) \approx 1$. Therefore, this chapter uses open-loop gain and loop-gain as synonyms.
+:::
+
+{{< include ./figures/_fig_feedback_system.qmd >}}
+
+::: {.callout-note title="Gain-bandwidth product in feedback systems"}
+The gain-bandwidth product (GBP or GBWP) or transit frequency $f_\mathrm{T}$ of a first-order open-loop system is the product of the open-loop DC gain $H_\mathrm{ol,DC} = H_\mathrm{ol}(f = 0\,\text{Hz})$ and the open-loop $-3\,\text{dB}$ cut-off frequency $f_\mathrm{c,ol}$ of $H_\mathrm{ol}(s)$.
+$$
+\text{GBWP} = f_\mathrm{T,ol} = H_\mathrm{ol,DC} f_\mathrm{c,ol}
+$$
+
+If a frequency-independent negative feedback $G$ (e.g. resistor divider) is applied to this open-loop system, the transit frequency changes to
+$$
+f_\mathrm{T,cl} = f_\mathrm{T,ol} \sqrt{1 - G^2}
+$$
+Hence, the closed-loop transit frequency is slightly lower than the open-loop transit frequency $f_\mathrm{T,cl} \leq f_\mathrm{T}$.
+
+The closed-loop $-3\,\text{dB}$ cut-off frequency $f_\mathrm{c,cl}$ can then be calculated from the open-loop transit frequency and the feedback gain.
+$$
+f_\mathrm{c,cl} = H_\mathrm{ol,DC} f_\mathrm{c,ol} G = f_\mathrm{T,ol} G
+$$
+
+This theory might be interesting when Middlebrook's and Tian's method are compared later for the MOSFET diode.
+:::
+
 The diode-connected MOSFET forms a feedback loop. What is the open-loop gain? For calculating it, we are breaking the loop, and apply a dummy $\Cgs^{*}$ at the right side to keep the impedances correct. A circuit diagram is shown in @fig-mosfet-diode-openloop, we break the loop at the dotted connection. As we can see in this example, it is critically important when breaking up a loop for analysis (also for simulation!) to keep the terminal impedances the same. Only in special cases where the load impedance is very high or the driving impedance is very low is it acceptable to disregard loading effects!
 
 {{< include ./figures/_fig_mosfet_diode_openloop.qmd >}}
@@ -111,7 +144,7 @@ $$
 
 The open-loop gain $H_\mathrm{ol}(s)$ is thus
 $$
-H_\mathrm{ol}(s) = \frac{v_\mathrm{out}}{v_\mathrm{in}} = -\frac{\gm}{\gds + s \Cgs}.
+H_\mathrm{ol}(s) = \frac{v_\mathrm{out}}{v_\mathrm{in}} = -\frac{\gm}{\gds + s \Cgs} = - \frac{\gm}{\gds} \frac{1}{1 + s \frac{\Cgs}{\gds}}.
 $$ {#eq-mosfet-diode-openloop-gain}
 
 Inspecting @eq-mosfet-diode-openloop-gain we realize that:
@@ -121,9 +154,11 @@ Inspecting @eq-mosfet-diode-openloop-gain we realize that:
 
 With this single pole location in $H_\mathrm{ol}(s)$ this loop is perfectly stable at under all conditions (remember that a single pole results in a maximum phase shift of --90$^\circ$).
 
-The question is now how to simulate this open-loop gain, i.e., how to break the loop open in simulation? In general there are various methods, as we can use artificially large (ideal) inductors and capacitors to break loops open and still establish the correct dc operating points for the ac loop analysis. However, mimicking the correct loading can be an issue, and requires a lot of careful consideration. 
+The question is now how to simulate this open-loop gain, i.e., how to break the loop open in simulation? In general there are various methods, as we can use artificially large (ideal) inductors and capacitors to break loops open and still establish the correct dc operating points for the ac loop analysis. This is called **Rosenstark's method** [@Rosenstark_1984]. However, mimicking the correct loading can be an issue, and requires a lot of careful consideration. 
 
 There is an alternative method which breaks the loop open only by adding an ac voltage source in series (thus keeps the dc operating point intact), or injects current using an ac current source. Based on both measurements the open-loop gain can be calculated. This is called **Middlebrook's method** [@Middlebrook_1975] and is based on double injection, and we will use it for our loop simulations. This method is detailed in @sec-middlebrook-method.
+
+There are several other methods like Tian's method [@Tian_2001] for example. A comprehensive overview can be found in [@loop_gain_analysis] which describes ten different simulation-based loop gain analysis methods.
 
 We now want to simulate the open-loop transfer function $H_\mathrm{ol}(s)$ by using Middlebrook's method and confirm our analysis above.
 
@@ -136,6 +171,12 @@ If you are getting stuck you can look at this Xschem [testbench](./xschem/mosfet
 :::
 
 From simulation we see that the open-loop gain is $24.9\,\text{dB}$ at low frequencies, which matches quite well our prediction of $26.4\,\text{dB}$. In the Bode plot we see a low-pass with a $-3\,\text{dB}$ corner frequency of $1.4\,\text{GHz}$, which again is fairly close to our prediction of $1.1\,\text{GHz}$. 
+
+::: {.callout-important title="What about large-signal stability?"}
+Keep in mind that the above simulation only verifies the small-signal stability in one certain operating point. If we later look at the stability of an OTA it might be a good idea to verify the small-signal stability in different operating points.
+
+Furthermore, one can apply a step response to the closed-loop system input and estimate the phase margin from the overshoot and the output (see "Automatic Control" lecture). One could also use a step-wise step response to simulate different operating points for a certain time (see "Introduction in Integrated Circuit Design" lecture).
+:::
 
 ## MOSFET Diode Noise Calculation
 
@@ -195,13 +236,17 @@ You fill find that the output noise is
 $$
 V_\mathrm{n,rms}^2 = \frac{k T}{C} 
 $$
-which is independent of $R$! This is a surprising result, and is the well-known $kT/C$ noise.
+which is independent of $R$! This is a surprising result, and is the well-known $kT/C$ noise. 
+Intuitively, we could argue that the noise increases with larger $R$ but at the same time, the bandwidth decreases and therefore $R$ does not add additional noise.
 
 Side note: The shortest derivation of this formula involves the [equipartition theorem](https://en.wikipedia.org/wiki/Equipartition_theorem): Any system in thermal equilibrium has an energy of $kT/2$ per degree of freedom. This $RC$ system has one degree of freedom in the capacitor, and the stored energy in the capacitor is $CV_\mathrm{rms}^2/2$. Equating both energies we find that $V_\mathrm{rms}^2 = kT/C$.
 :::
 
-
 Calculating the rms noise voltage for our MOSFET diode we get $\sqrt{V_\mathrm{n,rms}^2} = \sqrt{1.38 \cdot 10^{-23} \cdot 300 \cdot 0.84 / 1.4 \cdot 10^{-15}} = 1.58\,\text{mV}$, which is a sizeable value! We run circuits in this technology at $\VDD = 1.5\,\mathrm{V}$, which leaves us with a signal swing of ca. $1.1\,\mathrm{V_{pp}}$ (single-ended), resulting in a dynamic range in this case of $20 \log_{10} (0.39 / 1.58 \cdot 10^{-3}) \approx 48\,\text{dB}$ assuming a sinusoidal signal.
+
+::: {.callout-important title="Be careful with parasitic capacitances in IC design"}
+In general, in integrated circuit design, we often have small parasitic capacitances on many different nodes that could sum up to unwanted high noise according to @eq-mosfet-diode-noise-rms-simplified.
+:::
 
 ::: {.callout-important title="Large Bandwidth and Noise"}
 Remember: Large bandwidth circuits integrate noise over a wide bandwidth resulting in (potentially) considerable rms noise. The way to lower the total noise is to lower the PSD of the noise contributions, which usually requires increased power consumption. So in a nutshell:

--- a/figures/_fig_feedback_system.qmd
+++ b/figures/_fig_feedback_system.qmd
@@ -30,7 +30,7 @@ with sd.Drawing(canvas='svg') as d:
     elm.Line().right()
     sm = dsp.SumSigma()
     dsp.Arrow().right()
-    dsp.Box().label('$H_\mathrm{ol}(s)$')
+    dsp.Box().label(r'$H_\mathrm{ol}(s)$')
     elm.Line().right()
     elm.Dot()
     d.push()  # Save this drawing position/direction for later
@@ -42,7 +42,5 @@ with sd.Drawing(canvas='svg') as d:
     dsp.Box().label('$G(s)$')
     elm.Line().tox(sm.S)
     elm.Line().up().length(d.unit/2)
-    dsp.Arrow().toy(sm.S).label('-', loc='top')
-    
-    d.draw()
+    dsp.Arrow().toy(sm.S).label('$-$', loc='bottom')
 ```

--- a/figures/_fig_feedback_system.qmd
+++ b/figures/_fig_feedback_system.qmd
@@ -1,0 +1,48 @@
+::: {.content-hidden}
+Copyright (C) 2024 Harald Pretl and co-authors (harald.pretl@jku.at)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+:::
+
+```{python}
+#| label: fig-feedback-system
+#| echo: false
+#| fig-cap: "The block diagram of a negative feedback system."
+import schemdraw as sd
+import schemdraw.elements as elm
+import schemdraw.dsp as dsp
+sd.svgconfig.svg2 = False
+with sd.Drawing(canvas='svg') as d:
+    d.config(unit=2)
+    d.config(fontsize=16)
+    
+    elm.Dot(open=True).label('$X(s)$')
+    elm.Line().right()
+    sm = dsp.SumSigma()
+    dsp.Arrow().right()
+    dsp.Box().label('$H_\mathrm{ol}(s)$')
+    elm.Line().right()
+    elm.Dot()
+    d.push()  # Save this drawing position/direction for later
+    elm.Line().right()
+    elm.Dot(open=True).label('$Y(s)$')
+    d.pop()   # Return to the pushed position/direction
+    elm.Line().down().length(d.unit*1.5)
+    dsp.Arrow().left()
+    dsp.Box().label('$G(s)$')
+    elm.Line().tox(sm.S)
+    elm.Line().up().length(d.unit/2)
+    dsp.Arrow().toy(sm.S).label('-', loc='top')
+    
+    d.draw()
+```

--- a/references.bib
+++ b/references.bib
@@ -6,7 +6,27 @@
 
 %% Saved with string encoding Unicode (UTF-8) 
 
-
+@ARTICLE{loop_gain_analysis,
+	author={Neag, Marius and Oneţ, Raul and Kovács, István and Mărtari, Paul},
+	journal={IEEE Transactions on Circuits and Systems I: Regular Papers}, 
+	title={Comparative Analysis of Simulation-Based Methods for Deriving the Phase- and Gain-Margins of Feedback Circuits With Op-Amps}, 
+	year={2015},
+	volume={62},
+	number={3},
+	pages={625-634},
+	keywords={Integrated circuit modeling;Feedback circuits;Feedback loop;Mathematical model;Analytical models;Stability analysis;Circuit stability;Phase and gain margins;return ratio;stability},
+	doi={10.1109/TCSI.2014.2370151}}
+  
+@article{Rosenstark_1984,
+	author = {S. Rosenstark},
+	title = {Loop gain measurement in feedback amplifiers},
+	journal = {International Journal of Electronics},
+	volume = {57},
+	number = {3},
+	pages = {415--421},
+	year = {1984},
+	publisher = {Taylor \& Francis},
+	doi = {10.1080/00207218408938921}}
 
 @article{Tian_2001,
 	abstract = {{Based on Bode's definition of return ratio with respect to a single controlled source, the loop-based two-port algorithm and device-based gain-nulling are proposed for small-signal stability analysis. These two algorithms are complementary in terms of applicability, and they produce accurate stability information for single-loop networks. After a brief primer on feedback and stability, we review Bode's feedback theory, where the return difference and return ratio concepts are applicable to general feedback configurations and avoid the necessity of identifying μ and /spl beta/. Middlebrook's null double-injection technique, which provides a laboratory-based way to measure return ratio, is then discussed in the modern circuit analysis context; we then extend the unilateral feedback-model used in Middlebrook's approach to accommodate both normal-and reverse-loop transmission and characterize the return loop using a general two-port-analysis. This loop-based two-port algorithm determines the stability of a feedback network in which a critical wire can be located to break all return loops. The device-based gain-nulling algorithm is then discussed to evaluate the influence of the local return loops upon network stability. This algorithm determines the stability of a feedback network in which a controlled source can be nulled to render the network to be passive. Conditions under which these two algorithms can be applied are discussed.}},

--- a/references.bib
+++ b/references.bib
@@ -6,7 +6,7 @@
 
 %% Saved with string encoding Unicode (UTF-8) 
 
-@ARTICLE{loop_gain_analysis,
+@ARTICLE{Neag_2015,
 	author={Neag, Marius and Oneţ, Raul and Kovács, István and Mărtari, Paul},
 	journal={IEEE Transactions on Circuits and Systems I: Regular Papers}, 
 	title={Comparative Analysis of Simulation-Based Methods for Deriving the Phase- and Gain-Margins of Feedback Circuits With Op-Amps}, 
@@ -14,7 +14,6 @@
 	volume={62},
 	number={3},
 	pages={625-634},
-	keywords={Integrated circuit modeling;Feedback circuits;Feedback loop;Mathematical model;Analytical models;Stability analysis;Circuit stability;Phase and gain margins;return ratio;stability},
 	doi={10.1109/TCSI.2014.2370151}}
   
 @article{Rosenstark_1984,
@@ -29,22 +28,16 @@
 	doi = {10.1080/00207218408938921}}
 
 @article{Tian_2001,
-	abstract = {{Based on Bode's definition of return ratio with respect to a single controlled source, the loop-based two-port algorithm and device-based gain-nulling are proposed for small-signal stability analysis. These two algorithms are complementary in terms of applicability, and they produce accurate stability information for single-loop networks. After a brief primer on feedback and stability, we review Bode's feedback theory, where the return difference and return ratio concepts are applicable to general feedback configurations and avoid the necessity of identifying μ and /spl beta/. Middlebrook's null double-injection technique, which provides a laboratory-based way to measure return ratio, is then discussed in the modern circuit analysis context; we then extend the unilateral feedback-model used in Middlebrook's approach to accommodate both normal-and reverse-loop transmission and characterize the return loop using a general two-port-analysis. This loop-based two-port algorithm determines the stability of a feedback network in which a critical wire can be located to break all return loops. The device-based gain-nulling algorithm is then discussed to evaluate the influence of the local return loops upon network stability. This algorithm determines the stability of a feedback network in which a controlled source can be nulled to render the network to be passive. Conditions under which these two algorithms can be applied are discussed.}},
 	author = {Tian, M. and Visvanathan, V. and Hantgan, J. and Kundert, K.},
-	date-added = {2024-11-26 14:17:54 +0100},
-	date-modified = {2024-11-26 14:18:14 +0100},
 	journal = {IEEE Circuits and Devices Magazine},
 	number = {1},
 	pages = {31--41},
 	title = {{Striving for small-signal stability}},
 	volume = {17},
-	year = {2001},
-	bdsk-url-1 = {https://doi.org/10.1109/101.900125}}
+	year = {2001}}
 
 @book{Maxwell_1873,
 	author = {Maxwell, James Clerk},
-	date-added = {2024-11-05 13:55:14 +0100},
-	date-modified = {2024-11-05 13:56:49 +0100},
 	place = {Oxford},
 	publisher = {Clarendon Press},
 	title = {A Treatise on Electricity and Magnetism},
@@ -59,11 +52,8 @@
 	number = {3},
 	pages = {9--10},
 	title = {{Miller's Theorem [Circuit Intuitions]}},
-	url = {http://ieeexplore.ieee.org/document/7258480/},
 	volume = {7},
-	year = {2015},
-	bdsk-url-1 = {http://ieeexplore.ieee.org/document/7258480/},
-	bdsk-url-2 = {https://doi.org/10.1109/mssc.2015.2446457}}
+	year = {2015}}
 
 @article{Middlebrook_1975,
 	author = {Middlebrook, R. D.},
@@ -75,21 +65,18 @@
 	pages = {485--512},
 	title = {{Measurement of loop gain in feedback systems}},
 	volume = {38},
-	year = {1975},
-	bdsk-url-1 = {https://doi.org/10.1080/00207217508920421}}
+	year = {1975}}
 
 @article{Hellen_2003,
 	author = {Hellen, Edward H.},
 	doi = {10.1119/1.1578070},
 	journal = {American Journal of Physics},
-	local-url = {file://localhost/Users/harald/Documents/Papers%20Library/2003/2003-Hellen-Verifying%20the%20diode–capacitor%20circuit%20voltage%20decay.pdf},
 	month = {08},
 	number = {8},
 	pages = {797--800},
 	title = {{Verifying the diode--capacitor circuit voltage decay}},
 	volume = {71},
-	year = {2003},
-	bdsk-url-1 = {https://doi.org/10.1119/1.1578070}}
+	year = {2003}}
 
 @phdthesis{Nagel_1975,
 	author = {Nagel, Laurence W.},
@@ -98,8 +85,7 @@
 	school = {EECS Department, University of California, Berkeley},
 	title = {SPICE2: A Computer Program to Simulate Semiconductor Circuits},
 	url = {http://www2.eecs.berkeley.edu/Pubs/TechRpts/1975/9602.html},
-	year = {1975},
-	bdsk-url-1 = {http://www2.eecs.berkeley.edu/Pubs/TechRpts/1975/9602.html}}
+	year = {1975}}
 
 @book{Jespers_Murmann_2017,
 	author = {Jespers, Paul G. A. and Murmann, Boris},


### PR DESCRIPTION
-) Added a short recap about open-loop gain, closed-loop gain and loop gain.
-) Added some info about open- and closed-loop cut-off / transient frequencies. This was only added since this might be relevant for comparing Middlebrook and Tian's methods. If not, delete it.
-) Updated #eq-mosfet-diode-openloop-gain, some students are more comfortable with this notation since one can immediately see the gain and the pole of this transfer function.
-) Mentioned Rosenstark's method and referenced the paper.
-) Mentioned and referenced the paper which describes ten different simulation-based loop gain analysis methods.
-) Added an important note about large-signal stability (discussion during the lecture).
-) Added an intuitive thought by Prof. Pretl as to why #eq-mosfet-diode-noise-rms-simplified is independent of R.
-) Added an important note to be careful with parasitic capacitances in IC design due to #eq-mosfet-diode-noise-rms-simplified (discussion during the lecture).