### PR TITLE
Fix CMOS only PDK name

### DIFF
--- a/content/_sec_first_steps.qmd
+++ b/content/_sec_first_steps.qmd
@@ -16,7 +16,7 @@ limitations under the License.
 
 # First Steps {#sec-first-steps}
 
-In this first chapter we will learn to use Xschem for schematic entry, and how to operate the ngspice SPICE simulator for circuit simulations. Further, we will make ourself familiar with the transistor and other passive components available in the IHP Microelectronics SG13G2 technology. While this is strictly speaking a BiCMOS technology offering MOSFETs as well as SiGe heterojunction bipolar transistors (HBTs), we will use it as a pure CMOS technology, which is available from IHP under the name SG13S.
+In this first chapter we will learn to use Xschem for schematic entry, and how to operate the ngspice SPICE simulator for circuit simulations. Further, we will make ourself familiar with the transistor and other passive components available in the IHP Microelectronics SG13G2 technology. While this is strictly speaking a BiCMOS technology offering MOSFETs as well as SiGe heterojunction bipolar transistors (HBTs), we will use it as a pure CMOS technology, which is available from IHP under the name SG13C.
 
 ## The Metal-Oxide-Semiconductor Field-Effect-Transistor (MOSFET) {#sec-mosfet}
 


### PR DESCRIPTION
SG13S is an older BiCMOS process, the pure CMOS variant of SG13G2 is dubbed SG13C. Although IHP does not specify this naming on their website, it can be found at the MPW runs info page of [Europractice](https://europractice-ic.com/schedules-prices-2024/).