### PR TITLE
Reference for pole-zero doublets

### DIFF
--- a/content/_sec_basic_ota.qmd
+++ b/content/_sec_basic_ota.qmd
@@ -178,8 +178,7 @@ $$ {#eq-basic-ota-doublet-zero}
 
 ::: {.callout-note title="Why a Pole-Zero Doublet?"}
 Looking at @eq-basic-ota-doublet-pole and @eq-basic-ota-doublet-zero we see that this pair is intimately linked by the same parameters and can only move together. Hence we call it a "doublet". The effects of pole-zero doublets on the frequency response and settling time of OTAs can be found in [@Kamath_1974]. This paper shows that doublets
-may cause severe degradation of settling time while only causing
-minor changes in the frequency response of the amplifier.
+may cause severe degradation of settling time while only causing minor changes in the frequency response of the amplifier.
 :::
 
 ### OTA Noise

--- a/content/_sec_basic_ota.qmd
+++ b/content/_sec_basic_ota.qmd
@@ -177,7 +177,9 @@ s_\mathrm{zd} = -\frac{2 \gm[34]}{\Cgs[34]}
 $$ {#eq-basic-ota-doublet-zero}
 
 ::: {.callout-note title="Why a Pole-Zero Doublet?"}
-Looking at @eq-basic-ota-doublet-pole and @eq-basic-ota-doublet-zero we see that this pair is intimately linked by the same parameters and can only move together. Hence we call it a "doublet."
+Looking at @eq-basic-ota-doublet-pole and @eq-basic-ota-doublet-zero we see that this pair is intimately linked by the same parameters and can only move together. Hence we call it a "doublet". The effects of pole-zero doublets on the frequency response and settling time of OTAs can be found in [@Kamath_1974]. This paper shows that doublets
+may cause severe degradation of settling time while only causing
+minor changes in the frequency response of the amplifier.
 :::
 
 ### OTA Noise

--- a/references.bib
+++ b/references.bib
@@ -6,6 +6,17 @@
 
 %% Saved with string encoding Unicode (UTF-8) 
 
+@article{Kamath_1974,
+  author={Kamath, B.Y.T. and Meyer, R.G. and Gray, P.R.},
+  doi={10.1109/JSSC.1974.1050527},
+  journal={IEEE Journal of Solid-State Circuits},
+  number={6},
+  pages={347-352},
+  title={Relationship between frequency response and settling time of operational amplifiers}, 
+  volume={9},
+  year={1974},
+  keywords={Frequency response;Time factors;Operational amplifiers;Circuits;Educational institutions;Silicon;Physics;Computer simulation;Frequency estimation;Testing}}
+
 @online{Baker_compensating_OPAMP,
 author={R. J. Baker},
 title={Bad Circuit Design 3 - Compensating an Op-Amp},

--- a/references.bib
+++ b/references.bib
@@ -14,8 +14,7 @@
   pages={347-352},
   title={Relationship between frequency response and settling time of operational amplifiers}, 
   volume={9},
-  year={1974},
-  keywords={Frequency response;Time factors;Operational amplifiers;Circuits;Educational institutions;Silicon;Physics;Computer simulation;Frequency estimation;Testing}}
+  year={1974}}
 
 @online{Baker_compensating_OPAMP,
 author={R. J. Baker},


### PR DESCRIPTION
This paper nicely shows that the frequency response alone does not tell the whole story and how pole-zero doublets degrade the settling time.

Relationship between frequency response and settling time of operational amplifiers
https://ieeexplore.ieee.org/document/1050527