### PR TITLE
xschem: Make sure to use `devices/` prefix for all xschem default devices

### DIFF
--- a/xschem/bandgap_banba.sch
+++ b/xschem/bandgap_banba.sch
@@ -185,10 +185,10 @@ w=1.0e-6
 l=2.0e-6
 m=1
 }
-C {ammeter.sym} 890 -370 0 0 {name=Vmeas savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1430 -540 0 0 {name=Vmeas1 savecurrent=true spice_ignore=0}
-C {lab_pin.sym} 1130 -420 0 0 {name=p3 sig_type=std_logic lab=v2}
-C {lab_pin.sym} 1130 -320 0 0 {name=p4 sig_type=std_logic lab=v3}
+C {devices/ammeter.sym} 890 -370 0 0 {name=Vmeas savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1430 -540 0 0 {name=Vmeas1 savecurrent=true spice_ignore=0}
+C {devices/lab_pin.sym} 1130 -420 0 0 {name=p3 sig_type=std_logic lab=v2}
+C {devices/lab_pin.sym} 1130 -320 0 0 {name=p4 sig_type=std_logic lab=v3}
 C {ota-5t.sym} 650 -640 0 1 {name=xota}
 C {sg13g2_pr/sg13_lv_pmos.sym} 630 -870 0 1 {name=M4
 l=1u
@@ -198,9 +198,9 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {ammeter.sym} 890 -490 0 0 {name=Vmeas2 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1130 -490 0 0 {name=Vmeas3 savecurrent=true spice_ignore=0}
-C {lab_pin.sym} 810 -440 0 0 {name=p5 sig_type=std_logic lab=v1}
+C {devices/ammeter.sym} 890 -490 0 0 {name=Vmeas2 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1130 -490 0 0 {name=Vmeas3 savecurrent=true spice_ignore=0}
+C {devices/lab_pin.sym} 810 -440 0 0 {name=p5 sig_type=std_logic lab=v1}
 C {sg13g2_pr/sg13_lv_pmos.sym} 910 -870 0 1 {name=M1
 l=1u
 w=5u
@@ -225,7 +225,7 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {lab_pin.sym} 490 -740 0 0 {name=p6 sig_type=std_logic lab=vg}
+C {devices/lab_pin.sym} 490 -740 0 0 {name=p6 sig_type=std_logic lab=vg}
 C {sg13g2_pr/sg13_lv_nmos.sym} 470 -320 0 0 {name=M5
 l=0.13u
 w=1u
@@ -266,7 +266,7 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {lab_wire.sym} 370 -320 0 0 {name=p8 sig_type=std_logic lab=ena_n}
+C {devices/lab_wire.sym} 370 -320 0 0 {name=p8 sig_type=std_logic lab=ena_n}
 C {bandgap_banba_res-13k.sym} 1130 -340 0 0 {name=xr1}
 C {bandgap_banba_res-40k.sym} 1290 -340 0 0 {name=xr2a}
 C {bandgap_banba_res-40k.sym} 1290 -260 0 0 {name=xr2b}
@@ -305,7 +305,7 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {iopin.sym} 130 -1040 0 1 {name=p9 lab=vdd}
-C {iopin.sym} 130 -200 0 1 {name=p2 lab=vss}
-C {ipin.sym} 130 -520 0 0 {name=p7 lab=d_ena}
-C {opin.sym} 1590 -480 0 0 {name=p10 lab=vref_0v6}
+C {devices/iopin.sym} 130 -1040 0 1 {name=p9 lab=vdd}
+C {devices/iopin.sym} 130 -200 0 1 {name=p2 lab=vss}
+C {devices/ipin.sym} 130 -520 0 0 {name=p7 lab=d_ena}
+C {devices/opin.sym} 1590 -480 0 0 {name=p10 lab=vref_0v6}

--- a/xschem/bandgap_banba_res-13k.sch
+++ b/xschem/bandgap_banba_res-13k.sch
@@ -15,8 +15,8 @@ N 380 -180 420 -180 {lab=#net1}
 N 380 -280 380 -180 {lab=#net1}
 N 420 -200 420 -180 {lab=#net1}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="(c) 2024 H. Pretl, Apache-2.0 license"}
-C {iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
-C {iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
+C {devices/iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
+C {devices/iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
 C {sg13g2_pr/rhigh.sym} 260 -230 0 0 {name=R1
 w=0.5e-6
 l=3e-6

--- a/xschem/bandgap_banba_res-40k.sch
+++ b/xschem/bandgap_banba_res-40k.sch
@@ -17,10 +17,10 @@ lab=rn}
 N 180 -300 220 -300 {
 lab=rp}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="(c) 2024 H. Pretl, Apache-2.0 license"}
-C {iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
-C {iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
-C {lab_wire.sym} 310 -300 0 0 {name=p3 sig_type=std_logic lab=rp,r[1..3]}
-C {lab_wire.sym} 310 -160 0 0 {name=p4 sig_type=std_logic lab=r[1..3],rn}
+C {devices/iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
+C {devices/iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
+C {devices/lab_wire.sym} 310 -300 0 0 {name=p3 sig_type=std_logic lab=rp,r[1..3]}
+C {devices/lab_wire.sym} 310 -160 0 0 {name=p4 sig_type=std_logic lab=r[1..3],rn}
 C {sg13g2_pr/rhigh.sym} 320 -230 0 0 {name=R[1..4]
 w=0.5e-6
 l=3e-6

--- a/xschem/bandgap_banba_tb.sch
+++ b/xschem/bandgap_banba_tb.sch
@@ -69,11 +69,11 @@ C {devices/launcher.sym} 740 -150 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {lab_pin.sym} 560 -600 0 0 {name=p2 sig_type=std_logic lab=v_dd}
-C {lab_wire.sym} 1120 -520 0 0 {name=p1 sig_type=std_logic lab=vref}
-C {vsource.sym} 660 -390 0 0 {name=V1 value="1.5 pwl(0 0 1u 0 1.001u 1.5)" savecurrent=false}
-C {lab_pin.sym} 660 -520 0 0 {name=p7 sig_type=std_logic lab=ena}
+C {devices/lab_pin.sym} 560 -600 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_wire.sym} 1120 -520 0 0 {name=p1 sig_type=std_logic lab=vref}
+C {devices/vsource.sym} 660 -390 0 0 {name=V1 value="1.5 pwl(0 0 1u 0 1.001u 1.5)" savecurrent=false}
+C {devices/lab_pin.sym} 660 -520 0 0 {name=p7 sig_type=std_logic lab=ena}
 C {bandgap_banba.sym} 890 -520 0 0 {name=xbg}
-C {capa.sym} 1120 -430 0 0 {name=Cload
+C {devices/capa.sym} 1120 -430 0 0 {name=Cload
 m=1
 value=10f}

--- a/xschem/bandgap_simple.sch
+++ b/xschem/bandgap_simple.sch
@@ -154,7 +154,7 @@ C {devices/launcher.sym} 740 -150 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {lab_pin.sym} 380 -1040 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 380 -1040 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {sg13g2_pr/pnpMPA.sym} 580 -370 0 1 {name=Q1[1..2]
 model=pnpMPA
 spiceprefix=X
@@ -184,13 +184,13 @@ w=1.0e-6
 l=2.0e-6
 m=1
 }
-C {lab_wire.sym} 1380 -560 0 0 {name=p1 sig_type=std_logic lab=vref}
-C {ammeter.sym} 560 -470 0 0 {name=Vmeas savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1200 -640 0 0 {name=Vmeas1 savecurrent=true spice_ignore=0}
-C {lab_pin.sym} 1000 -520 0 0 {name=p3 sig_type=std_logic lab=v2}
-C {lab_pin.sym} 1000 -420 0 0 {name=p4 sig_type=std_logic lab=v3}
-C {lab_pin.sym} 560 -520 0 0 {name=p5 sig_type=std_logic lab=v1}
-C {lab_wire.sym} 680 -970 0 0 {name=p6 sig_type=std_logic lab=vg4}
+C {devices/lab_wire.sym} 1380 -560 0 0 {name=p1 sig_type=std_logic lab=vref}
+C {devices/ammeter.sym} 560 -470 0 0 {name=Vmeas savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1200 -640 0 0 {name=Vmeas1 savecurrent=true spice_ignore=0}
+C {devices/lab_pin.sym} 1000 -520 0 0 {name=p3 sig_type=std_logic lab=v2}
+C {devices/lab_pin.sym} 1000 -420 0 0 {name=p4 sig_type=std_logic lab=v3}
+C {devices/lab_pin.sym} 560 -520 0 0 {name=p5 sig_type=std_logic lab=v1}
+C {devices/lab_wire.sym} 680 -970 0 0 {name=p6 sig_type=std_logic lab=vg4}
 C {sg13g2_pr/sg13_lv_pmos.sym} 580 -890 0 1 {name=M4B
 l=1u
 w=50u
@@ -199,9 +199,9 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {lab_wire.sym} 700 -570 0 0 {name=p7 sig_type=std_logic lab=vg1}
-C {lab_wire.sym} 700 -650 0 0 {name=p8 sig_type=std_logic lab=vg2}
-C {lab_wire.sym} 680 -890 0 0 {name=p9 sig_type=std_logic lab=vg3}
+C {devices/lab_wire.sym} 700 -570 0 0 {name=p7 sig_type=std_logic lab=vg1}
+C {devices/lab_wire.sym} 700 -650 0 0 {name=p8 sig_type=std_logic lab=vg2}
+C {devices/lab_wire.sym} 680 -890 0 0 {name=p9 sig_type=std_logic lab=vg3}
 C {sg13g2_pr/sg13_lv_nmos.sym} 580 -650 0 1 {name=M1B
 l=1u
 w=15u
@@ -274,7 +274,7 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {ammeter.sym} 760 -710 0 0 {name=Vmeas2 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 760 -710 0 0 {name=Vmeas2 savecurrent=true spice_ignore=0}
 C {bandgap_simple_res-6k.sym} 1000 -440 0 1 {name=xr1}
 C {bandgap_simple_res-10k.sym} 560 -720 0 1 {name=xr4}
 C {bandgap_simple_res-10k.sym} 1000 -760 0 0 {name=xr3}

--- a/xschem/bandgap_simple_res-10k.sch
+++ b/xschem/bandgap_simple_res-10k.sch
@@ -17,10 +17,10 @@ lab=rn}
 N 180 -300 220 -300 {
 lab=rp}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="(c) 2024 H. Pretl, Apache-2.0 license"}
-C {iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
-C {iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
-C {lab_wire.sym} 310 -300 0 0 {name=p3 sig_type=std_logic lab=rp,r[1]}
-C {lab_wire.sym} 310 -160 0 0 {name=p4 sig_type=std_logic lab=r[1],rn}
+C {devices/iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
+C {devices/iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
+C {devices/lab_wire.sym} 310 -300 0 0 {name=p3 sig_type=std_logic lab=rp,r[1]}
+C {devices/lab_wire.sym} 310 -160 0 0 {name=p4 sig_type=std_logic lab=r[1],rn}
 C {sg13g2_pr/rppd.sym} 320 -230 0 0 {name=R[1..2]
 w=0.5e-6
 l=10e-6

--- a/xschem/bandgap_simple_res-37k5.sch
+++ b/xschem/bandgap_simple_res-37k5.sch
@@ -28,10 +28,10 @@ N 360 -500 360 -460 {lab=rp}
 N 220 -500 360 -500 {lab=rp}
 N 220 -500 220 -460 {lab=rp}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="(c) 2025 H. Pretl, Apache-2.0 license"}
-C {iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
-C {iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
-C {lab_wire.sym} 450 -300 0 0 {name=p5 sig_type=std_logic lab=rp1,r[1..6]}
-C {lab_wire.sym} 450 -160 0 0 {name=p6 sig_type=std_logic lab=r[1..6],rn}
+C {devices/iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
+C {devices/iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
+C {devices/lab_wire.sym} 450 -300 0 0 {name=p5 sig_type=std_logic lab=rp1,r[1..6]}
+C {devices/lab_wire.sym} 450 -160 0 0 {name=p6 sig_type=std_logic lab=r[1..6],rn}
 C {sg13g2_pr/rppd.sym} 460 -230 0 0 {name=R[1..7]
 w=0.5e-6
 l=10e-6
@@ -48,7 +48,7 @@ spiceprefix=X
 b=0
 m=1
 }
-C {lab_wire.sym} 360 -300 0 0 {name=p3 sig_type=std_logic lab=rp1}
+C {devices/lab_wire.sym} 360 -300 0 0 {name=p3 sig_type=std_logic lab=rp1}
 C {sg13g2_pr/rppd.sym} 290 -460 1 0 {name=Rdummy[1..5]
 w=0.5e-6
 l=10e-6

--- a/xschem/bandgap_simple_res-6k.sch
+++ b/xschem/bandgap_simple_res-6k.sch
@@ -15,8 +15,8 @@ N 360 -280 360 -160 {lab=#net1}
 N 360 -160 400 -160 {lab=#net1}
 N 400 -200 400 -160 {lab=#net1}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="(c) 2025 H. Pretl, Apache-2.0 license"}
-C {iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
-C {iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
+C {devices/iopin.sym} 180 -300 0 1 {name=p2 lab=rp}
+C {devices/iopin.sym} 180 -160 0 1 {name=p1 lab=rn}
 C {sg13g2_pr/rppd.sym} 240 -230 0 0 {name=R1
 w=0.5e-6
 l=10e-6

--- a/xschem/current_mirror.sch
+++ b/xschem/current_mirror.sch
@@ -158,9 +158,9 @@ C {devices/launcher.sym} 740 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {isource.sym} 610 -490 0 0 {name=Ibias value=20u}
-C {lab_pin.sym} 680 -370 0 1 {name=p1 sig_type=std_logic lab=v_gs}
-C {lab_pin.sym} 380 -540 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/isource.sym} 610 -490 0 0 {name=Ibias value=20u}
+C {devices/lab_pin.sym} 680 -370 0 1 {name=p1 sig_type=std_logic lab=v_gs}
+C {devices/lab_pin.sym} 380 -540 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {sg13g2_pr/sg13_lv_nmos.sym} 800 -370 0 0 {name=M2
 l=0.13u
 w=0.5u
@@ -189,13 +189,13 @@ C {devices/vsource.sym} 940 -350 0 0 {name=Vout1 value=0.6
 }
 C {devices/vsource.sym} 1180 -350 0 0 {name=Vout2 value=0.6}
 C {devices/vsource.sym} 1440 -350 0 0 {name=Vout3 value=0.6}
-C {spice_probe.sym} 820 -520 0 0 {name=p3 attrs=""}
-C {spice_probe.sym} 1060 -520 0 0 {name=p4 attrs=""}
-C {spice_probe.sym} 1320 -520 0 0 {name=p5 attrs=""}
-C {spice_probe.sym} 700 -420 0 0 {name=p6 attrs=""}
-C {lab_pin.sym} 940 -520 0 1 {name=p7 sig_type=std_logic lab=out1}
-C {lab_pin.sym} 1180 -520 0 1 {name=p8 sig_type=std_logic lab=out2}
-C {lab_pin.sym} 1440 -520 0 1 {name=p9 sig_type=std_logic lab=out3}
-C {ammeter.sym} 820 -470 0 0 {name=Viout1 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1060 -470 0 0 {name=Viout2 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1320 -470 0 0 {name=Viout3 savecurrent=true spice_ignore=0}
+C {devices/spice_probe.sym} 820 -520 0 0 {name=p3 attrs=""}
+C {devices/spice_probe.sym} 1060 -520 0 0 {name=p4 attrs=""}
+C {devices/spice_probe.sym} 1320 -520 0 0 {name=p5 attrs=""}
+C {devices/spice_probe.sym} 700 -420 0 0 {name=p6 attrs=""}
+C {devices/lab_pin.sym} 940 -520 0 1 {name=p7 sig_type=std_logic lab=out1}
+C {devices/lab_pin.sym} 1180 -520 0 1 {name=p8 sig_type=std_logic lab=out2}
+C {devices/lab_pin.sym} 1440 -520 0 1 {name=p9 sig_type=std_logic lab=out3}
+C {devices/ammeter.sym} 820 -470 0 0 {name=Viout1 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1060 -470 0 0 {name=Viout2 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1320 -470 0 0 {name=Viout3 savecurrent=true spice_ignore=0}

--- a/xschem/current_mirror_improved.sch
+++ b/xschem/current_mirror_improved.sch
@@ -159,9 +159,9 @@ C {devices/launcher.sym} 740 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {isource.sym} 610 -490 0 0 {name=Ibias value=20u}
-C {lab_pin.sym} 680 -370 0 1 {name=p1 sig_type=std_logic lab=v_gs}
-C {lab_pin.sym} 380 -540 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/isource.sym} 610 -490 0 0 {name=Ibias value=20u}
+C {devices/lab_pin.sym} 680 -370 0 1 {name=p1 sig_type=std_logic lab=v_gs}
+C {devices/lab_pin.sym} 380 -540 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {sg13g2_pr/sg13_lv_nmos.sym} 800 -370 0 0 {name=M2
 l=5u
 w=2u
@@ -190,13 +190,13 @@ C {devices/vsource.sym} 940 -350 0 0 {name=Vout1 value=0.6
 }
 C {devices/vsource.sym} 1180 -350 0 0 {name=Vout2 value=0.6}
 C {devices/vsource.sym} 1440 -350 0 0 {name=Vout3 value=0.6}
-C {spice_probe.sym} 820 -520 0 0 {name=p3 attrs=""}
-C {spice_probe.sym} 1060 -520 0 0 {name=p4 attrs=""}
-C {spice_probe.sym} 1320 -520 0 0 {name=p5 attrs=""}
-C {spice_probe.sym} 700 -420 0 0 {name=p6 attrs=""}
-C {lab_pin.sym} 940 -520 0 1 {name=p7 sig_type=std_logic lab=out1}
-C {lab_pin.sym} 1180 -520 0 1 {name=p8 sig_type=std_logic lab=out2}
-C {lab_pin.sym} 1440 -520 0 1 {name=p9 sig_type=std_logic lab=out3}
-C {ammeter.sym} 820 -470 0 0 {name=Viout1 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1060 -470 0 0 {name=Viout2 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1320 -470 0 0 {name=Viout3 savecurrent=true spice_ignore=0}
+C {devices/spice_probe.sym} 820 -520 0 0 {name=p3 attrs=""}
+C {devices/spice_probe.sym} 1060 -520 0 0 {name=p4 attrs=""}
+C {devices/spice_probe.sym} 1320 -520 0 0 {name=p5 attrs=""}
+C {devices/spice_probe.sym} 700 -420 0 0 {name=p6 attrs=""}
+C {devices/lab_pin.sym} 940 -520 0 1 {name=p7 sig_type=std_logic lab=out1}
+C {devices/lab_pin.sym} 1180 -520 0 1 {name=p8 sig_type=std_logic lab=out2}
+C {devices/lab_pin.sym} 1440 -520 0 1 {name=p9 sig_type=std_logic lab=out3}
+C {devices/ammeter.sym} 820 -470 0 0 {name=Viout1 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1060 -470 0 0 {name=Viout2 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1320 -470 0 0 {name=Viout3 savecurrent=true spice_ignore=0}

--- a/xschem/measurement_amplifier.sch
+++ b/xschem/measurement_amplifier.sch
@@ -87,15 +87,15 @@ C {devices/launcher.sym} 380 -160 0 0 {name=h2
 descr="simulate" 
 tclcommand="xschem save; xschem netlist; xschem simulate"
 }
-C {res.sym} 800 -370 0 0 {name=Rload
+C {devices/res.sym} 800 -370 0 0 {name=Rload
 value=50
 device=resistor
 m=1}
-C {res.sym} 640 -370 0 0 {name=R2
+C {devices/res.sym} 640 -370 0 0 {name=R2
 value=50
 device=resistor
 m=1}
-C {ammeter.sym} 640 -510 0 0 {name=Vmeas savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 640 -510 0 0 {name=Vmeas savecurrent=true spice_ignore=0}
 C {sg13g2_pr/sg13_lv_pmos.sym} 620 -610 0 0 {name=M1
 l=0.13u
 w=260u
@@ -105,18 +105,18 @@ model=sg13_lv_pmos
 spiceprefix=X
 }
 C {devices/vsource.sym} 480 -430 0 0 {name=Vsrc value="dc 0.899 ac 1"}
-C {lab_wire.sym} 480 -680 0 0 {name=p3 sig_type=std_logic lab=vdd}
-C {lab_wire.sym} 560 -610 0 0 {name=p1 sig_type=std_logic lab=vin}
-C {lab_wire.sym} 740 -440 0 0 {name=p2 sig_type=std_logic lab=vout}
+C {devices/lab_wire.sym} 480 -680 0 0 {name=p3 sig_type=std_logic lab=vdd}
+C {devices/lab_wire.sym} 560 -610 0 0 {name=p1 sig_type=std_logic lab=vin}
+C {devices/lab_wire.sym} 740 -440 0 0 {name=p2 sig_type=std_logic lab=vout}
 C {devices/launcher.sym} 620 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {res.sym} 480 -530 0 0 {name=R1
+C {devices/res.sym} 480 -530 0 0 {name=R1
 value=1k
 device=resistor
 m=1}
-C {launcher.sym} 880 -160 0 0 {name=h5
+C {devices/launcher.sym} 880 -160 0 0 {name=h5
 descr="load waves" 
 tclcommand="xschem raw_read $netlist_dir/measurement_amplifier.raw ac"
 }

--- a/xschem/mosfet_diode_loopgain.sch
+++ b/xschem/mosfet_diode_loopgain.sch
@@ -177,11 +177,11 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {isource.sym} 1240 -350 0 0 {name=Ibias1 value=20u}
-C {lab_pin.sym} 880 -420 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/isource.sym} 1240 -350 0 0 {name=Ibias1 value=20u}
+C {devices/lab_pin.sym} 880 -420 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {devices/vsource.sym} 1130 -300 3 0 {name=Vtest1 value="dc 0 ac 1"}
-C {lab_wire.sym} 1060 -300 0 0 {name=p1 sig_type=std_logic lab=vf1}
-C {lab_wire.sym} 1210 -300 0 0 {name=p3 sig_type=std_logic lab=vr1}
+C {devices/lab_wire.sym} 1060 -300 0 0 {name=p1 sig_type=std_logic lab=vf1}
+C {devices/lab_wire.sym} 1210 -300 0 0 {name=p3 sig_type=std_logic lab=vr1}
 C {devices/gnd.sym} 1740 -160 0 0 {name=l2 lab=GND}
 C {devices/gnd.sym} 1810 -160 0 0 {name=l6 lab=GND}
 C {sg13g2_pr/sg13_lv_nmos.sym} 1720 -250 0 0 {name=M2
@@ -192,12 +192,12 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {isource.sym} 1740 -350 0 0 {name=Ibias2 value=20u}
-C {ammeter.sym} 1670 -300 1 0 {name=Vir1 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1570 -300 1 0 {name=Vif1 savecurrent=true spice_ignore=0}
-C {isource.sym} 1620 -190 2 0 {name=Itest1 value="dc 0 ac 1"}
+C {devices/isource.sym} 1740 -350 0 0 {name=Ibias2 value=20u}
+C {devices/ammeter.sym} 1670 -300 1 0 {name=Vir1 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1570 -300 1 0 {name=Vif1 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 1620 -190 2 0 {name=Itest1 value="dc 0 ac 1"}
 C {devices/gnd.sym} 1620 -160 0 0 {name=l7 lab=GND}
-C {lab_wire.sym} 1520 -250 0 0 {name=p4 sig_type=std_logic lab=v_gs}
+C {devices/lab_wire.sym} 1520 -250 0 0 {name=p4 sig_type=std_logic lab=v_gs}
 C {devices/launcher.sym} 860 -1040 0 0 {name=h2
 descr="Annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
@@ -216,8 +216,8 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {isource.sym} 1240 -810 0 0 {name=Ibias3 value=20u}
-C {lab_pin.sym} 880 -880 0 0 {name=p5 sig_type=std_logic lab=v_dd}
+C {devices/isource.sym} 1240 -810 0 0 {name=Ibias3 value=20u}
+C {devices/lab_pin.sym} 880 -880 0 0 {name=p5 sig_type=std_logic lab=v_dd}
 C {devices/gnd.sym} 1740 -620 0 0 {name=l11 lab=GND}
 C {devices/gnd.sym} 1810 -620 0 0 {name=l12 lab=GND}
 C {sg13g2_pr/sg13_lv_nmos.sym} 1720 -710 0 0 {name=M4
@@ -228,14 +228,14 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {isource.sym} 1740 -810 0 0 {name=Ibias4 value=20u}
-C {isource.sym} 1020 -660 2 0 {name=Itest2 value="dc 0 ac 0"}
+C {devices/isource.sym} 1740 -810 0 0 {name=Ibias4 value=20u}
+C {devices/isource.sym} 1020 -660 2 0 {name=Itest2 value="dc 0 ac 0"}
 C {devices/gnd.sym} 1020 -620 0 0 {name=l9 lab=GND}
-C {isource.sym} 1520 -660 2 0 {name=Itest3 value="dc 0 ac 1"}
+C {devices/isource.sym} 1520 -660 2 0 {name=Itest3 value="dc 0 ac 1"}
 C {devices/gnd.sym} 1520 -620 0 0 {name=l13 lab=GND}
 C {devices/vsource.sym} 1070 -760 3 0 {name=Vtest2 value="dc 0 ac 1"}
 C {devices/vsource.sym} 1570 -760 3 0 {name=Vtest3 value="dc 0 ac 0"}
-C {lab_wire.sym} 980 -710 0 0 {name=p6 sig_type=std_logic lab=vmeas1}
-C {lab_wire.sym} 1480 -710 0 0 {name=p7 sig_type=std_logic lab=vmeas2}
-C {ammeter.sym} 1170 -760 1 0 {name=Vimeas1 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1670 -760 1 0 {name=Vimeas2 savecurrent=true spice_ignore=0}
+C {devices/lab_wire.sym} 980 -710 0 0 {name=p6 sig_type=std_logic lab=vmeas1}
+C {devices/lab_wire.sym} 1480 -710 0 0 {name=p7 sig_type=std_logic lab=vmeas2}
+C {devices/ammeter.sym} 1170 -760 1 0 {name=Vimeas1 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1670 -760 1 0 {name=Vimeas2 savecurrent=true spice_ignore=0}

--- a/xschem/mosfet_diode_noise.sch
+++ b/xschem/mosfet_diode_noise.sch
@@ -69,6 +69,6 @@ C {devices/launcher.sym} 740 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {isource.sym} 750 -470 0 0 {name=Ibias value="dc 20u ac 1"}
-C {lab_pin.sym} 680 -420 0 0 {name=p1 sig_type=std_logic lab=v_gs}
-C {lab_pin.sym} 520 -540 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/isource.sym} 750 -470 0 0 {name=Ibias value="dc 20u ac 1"}
+C {devices/lab_pin.sym} 680 -420 0 0 {name=p1 sig_type=std_logic lab=v_gs}
+C {devices/lab_pin.sym} 520 -540 0 0 {name=p2 sig_type=std_logic lab=v_dd}

--- a/xschem/mosfet_diode_settling.sch
+++ b/xschem/mosfet_diode_settling.sch
@@ -105,13 +105,13 @@ C {devices/launcher.sym} 380 -160 0 0 {name=h2
 descr="simulate" 
 tclcommand="xschem save; xschem netlist; xschem simulate"
 }
-C {isource.sym} 570 -630 0 0 {name=Ibias value="dc 0 pwl(0 0 10p 0 11p 20u 100p 20u 101p 0)"}
-C {lab_pin.sym} 500 -370 0 0 {name=p1 sig_type=std_logic lab=v_gs}
-C {lab_pin.sym} 340 -680 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/isource.sym} 570 -630 0 0 {name=Ibias value="dc 0 pwl(0 0 10p 0 11p 20u 100p 20u 101p 0)"}
+C {devices/lab_pin.sym} 500 -370 0 0 {name=p1 sig_type=std_logic lab=v_gs}
+C {devices/lab_pin.sym} 340 -680 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {devices/launcher.sym} 620 -160 0 0 {name=h1
 descr="load waves" 
 tclcommand="xschem raw_read $netlist_dir/mosfet_diode_settling.raw"
 }
-C {spice_probe.sym} 500 -500 0 0 {name=p3 attrs=""}
-C {ammeter.sym} 570 -450 0 0 {name=Vid savecurrent=true spice_ignore=0}
-C {ammeter.sym} 570 -550 0 0 {name=Vibias savecurrent=true spice_ignore=0}
+C {devices/spice_probe.sym} 500 -500 0 0 {name=p3 attrs=""}
+C {devices/ammeter.sym} 570 -450 0 0 {name=Vid savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 570 -550 0 0 {name=Vibias savecurrent=true spice_ignore=0}

--- a/xschem/mosfet_diode_sizing.sch
+++ b/xschem/mosfet_diode_sizing.sch
@@ -91,7 +91,7 @@ C {devices/ngspice_get_value.sym} 320 -260 0 1 {name=r10 node=v(@n.xm1.nsg13_lv_
 descr="sid="}
 C {devices/ngspice_get_value.sym} 220 -170 0 1 {name=r11 node=v(@n.xm1.nsg13_lv_nmos[rg])
 descr="rg="}
-C {isource.sym} 750 -470 0 0 {name=Ibias value=20u}
-C {lab_pin.sym} 680 -420 0 0 {name=p1 sig_type=std_logic lab=v_gs}
-C {lab_pin.sym} 520 -540 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/isource.sym} 750 -470 0 0 {name=Ibias value=20u}
+C {devices/lab_pin.sym} 680 -420 0 0 {name=p1 sig_type=std_logic lab=v_gs}
+C {devices/lab_pin.sym} 520 -540 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {sg13g2_pr/annotate_fet_params.sym} 900 -430 0 0 {name=annot1 ref=M1}

--- a/xschem/ota-5t.sch
+++ b/xschem/ota-5t.sch
@@ -260,12 +260,12 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {ipin.sym} 160 -440 0 0 {name=p1 lab=ibias_20u}
-C {iopin.sym} 160 -860 0 1 {name=p2 lab=vdd}
-C {iopin.sym} 160 -160 0 1 {name=p3 lab=vss}
-C {ipin.sym} 160 -590 0 0 {name=p4 lab=vinp}
-C {ipin.sym} 160 -500 0 0 {name=p5 lab=vinn}
-C {opin.sym} 1140 -640 0 0 {name=p6 lab=vout}
+C {devices/ipin.sym} 160 -440 0 0 {name=p1 lab=ibias_20u}
+C {devices/iopin.sym} 160 -860 0 1 {name=p2 lab=vdd}
+C {devices/iopin.sym} 160 -160 0 1 {name=p3 lab=vss}
+C {devices/ipin.sym} 160 -590 0 0 {name=p4 lab=vinp}
+C {devices/ipin.sym} 160 -500 0 0 {name=p5 lab=vinn}
+C {devices/opin.sym} 1140 -640 0 0 {name=p6 lab=vout}
 C {sg13g2_pr/sg13_lv_nmos.sym} 400 -210 0 0 {name=M7
 l=0.13u
 w=0.5u
@@ -282,7 +282,7 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {ipin.sym} 160 -260 0 0 {name=p7 lab=d_ena}
+C {devices/ipin.sym} 160 -260 0 0 {name=p7 lab=d_ena}
 C {sg13g2_pr/sg13_lv_nmos.sym} 720 -390 0 0 {name=M10
 l=0.13u
 w=0.5u
@@ -291,10 +291,10 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {lab_wire.sym} 690 -210 0 0 {name=p8 sig_type=std_logic lab=ena_n}
-C {lab_wire.sym} 800 -280 0 0 {name=p9 sig_type=std_logic lab=gate_n}
-C {lab_wire.sym} 940 -710 0 0 {name=p10 sig_type=std_logic lab=gate_p}
-C {lab_wire.sym} 900 -440 0 0 {name=p11 sig_type=std_logic lab=tail}
+C {devices/lab_wire.sym} 690 -210 0 0 {name=p8 sig_type=std_logic lab=ena_n}
+C {devices/lab_wire.sym} 800 -280 0 0 {name=p9 sig_type=std_logic lab=gate_n}
+C {devices/lab_wire.sym} 940 -710 0 0 {name=p10 sig_type=std_logic lab=gate_p}
+C {devices/lab_wire.sym} 900 -440 0 0 {name=p11 sig_type=std_logic lab=tail}
 C {sg13g2_pr/sg13_lv_nmos.sym} 240 -210 0 0 {name=M12
 l=0.13u
 w=0.5u
@@ -311,7 +311,7 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {lab_wire.sym} 590 -390 0 0 {name=p12 sig_type=std_logic lab=ena}
+C {devices/lab_wire.sym} 590 -390 0 0 {name=p12 sig_type=std_logic lab=ena}
 C {sg13g2_pr/annotate_fet_params.sym} 1280 -310 0 0 {name=annot1 ref=M5}
 C {sg13g2_pr/annotate_fet_params.sym} 1280 -520 0 0 {name=annot2 ref=M1}
 C {sg13g2_pr/annotate_fet_params.sym} 1440 -520 0 0 {name=annot3 ref=M2}

--- a/xschem/ota-5t_tb-ac.sch
+++ b/xschem/ota-5t_tb-ac.sch
@@ -102,22 +102,22 @@ C {devices/launcher.sym} 920 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {ota-5t.sym} 1050 -630 0 0 {name=xota}
 C {devices/vsource.sym} 600 -330 0 0 {name=Vss value=0}
 C {devices/gnd.sym} 600 -280 0 0 {name=l1 lab=GND}
-C {lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1300 -560 0 0 {name=C1
+C {devices/lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1300 -560 0 0 {name=C1
 value=50f}
-C {lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
+C {devices/lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
 C {devices/vsource.sym} 700 -540 0 0 {name=Vin value="dc 0.8 ac 1"}
-C {lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_in}
-C {isource.sym} 1090 -780 0 0 {name=I0 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {vsource.sym} 1090 -430 0 0 {name=Venable value=1.5 savecurrent=false}
-C {spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
-C {spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
-C {spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
-C {lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 1090 -780 0 0 {name=I0 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/vsource.sym} 1090 -430 0 0 {name=Venable value=1.5 savecurrent=false}
+C {devices/spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
+C {devices/spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
+C {devices/spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
+C {devices/lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
 C {devices/code_shown.sym} 0 -190 0 0 {name=SAVE only_toplevel=true
 format="tcleval( @value )"
 value=".include [file rootname [xschem get schname]].save

--- a/xschem/ota-5t_tb-loopgain.sch
+++ b/xschem/ota-5t_tb-loopgain.sch
@@ -181,59 +181,59 @@ tclcommand="xschem save; xschem netlist; xschem simulate"
 }
 C {devices/vsource.sym} 720 -190 0 0 {name=Vdd value=1.5}
 C {devices/gnd.sym} 720 -140 0 0 {name=l3 lab=GND}
-C {lab_pin.sym} 720 -240 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 720 -240 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {devices/vsource.sym} 880 -190 0 0 {name=Vss value=0}
 C {devices/gnd.sym} 880 -140 0 0 {name=l1 lab=GND}
-C {lab_pin.sym} 880 -240 0 0 {name=p1 sig_type=std_logic lab=v_ss}
+C {devices/lab_pin.sym} 880 -240 0 0 {name=p1 sig_type=std_logic lab=v_ss}
 C {devices/vsource.sym} 720 -350 0 0 {name=Vin value="dc 0.75"}
-C {lab_wire.sym} 720 -400 0 0 {name=p4 sig_type=std_logic lab=v_in}
-C {vsource.sym} 880 -350 0 0 {name=Venable value=1.5 savecurrent=false}
-C {lab_wire.sym} 880 -400 0 1 {name=p8 sig_type=std_logic lab=v_ena}
-C {lab_pin.sym} 1340 -580 0 0 {name=p5 sig_type=std_logic lab=v_dd}
-C {lab_pin.sym} 1340 -220 0 0 {name=p6 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1580 -310 0 0 {name=C2
+C {devices/lab_wire.sym} 720 -400 0 0 {name=p4 sig_type=std_logic lab=v_in}
+C {devices/vsource.sym} 880 -350 0 0 {name=Venable value=1.5 savecurrent=false}
+C {devices/lab_wire.sym} 880 -400 0 1 {name=p8 sig_type=std_logic lab=v_ena}
+C {devices/lab_pin.sym} 1340 -580 0 0 {name=p5 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 1340 -220 0 0 {name=p6 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1580 -310 0 0 {name=C2
 value=50f}
-C {lab_wire.sym} 1100 -430 0 0 {name=p9 sig_type=std_logic lab=v_in}
-C {isource.sym} 1380 -530 0 0 {name=I1 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {lab_wire.sym} 1380 -300 0 1 {name=p10 sig_type=std_logic lab=v_ena}
-C {lab_pin.sym} 720 -300 0 0 {name=p11 sig_type=std_logic lab=v_ss}
-C {lab_pin.sym} 880 -300 0 0 {name=p12 sig_type=std_logic lab=v_ss}
+C {devices/lab_wire.sym} 1100 -430 0 0 {name=p9 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 1380 -530 0 0 {name=I1 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/lab_wire.sym} 1380 -300 0 1 {name=p10 sig_type=std_logic lab=v_ena}
+C {devices/lab_pin.sym} 720 -300 0 0 {name=p11 sig_type=std_logic lab=v_ss}
+C {devices/lab_pin.sym} 880 -300 0 0 {name=p12 sig_type=std_logic lab=v_ss}
 C {ota-5t.sym} 1340 -400 0 0 {name=x1}
 C {devices/vsource.sym} 1210 -280 3 0 {name=Vtest1 value="dc 0 ac 1"}
-C {lab_wire.sym} 1140 -280 0 0 {name=p3 sig_type=std_logic lab=vf1}
-C {lab_wire.sym} 1290 -280 0 0 {name=p13 sig_type=std_logic lab=vr1}
-C {lab_pin.sym} 2100 -580 0 0 {name=p14 sig_type=std_logic lab=v_dd}
-C {lab_pin.sym} 2100 -220 0 0 {name=p15 sig_type=std_logic lab=v_ss}
-C {capa.sym} 2340 -310 0 0 {name=C1
+C {devices/lab_wire.sym} 1140 -280 0 0 {name=p3 sig_type=std_logic lab=vf1}
+C {devices/lab_wire.sym} 1290 -280 0 0 {name=p13 sig_type=std_logic lab=vr1}
+C {devices/lab_pin.sym} 2100 -580 0 0 {name=p14 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 2100 -220 0 0 {name=p15 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 2340 -310 0 0 {name=C1
 value=50f}
-C {lab_wire.sym} 1860 -430 0 0 {name=p17 sig_type=std_logic lab=v_in}
-C {isource.sym} 2140 -530 0 0 {name=I2 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {lab_wire.sym} 2140 -300 0 1 {name=p18 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 1860 -430 0 0 {name=p17 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 2140 -530 0 0 {name=I2 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/lab_wire.sym} 2140 -300 0 1 {name=p18 sig_type=std_logic lab=v_ena}
 C {ota-5t.sym} 2100 -400 0 0 {name=x2}
-C {ammeter.sym} 2030 -280 1 0 {name=Vir1 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1930 -280 1 0 {name=Vif1 savecurrent=true spice_ignore=0}
-C {isource.sym} 1980 -210 2 0 {name=Itest1 value="dc 0 ac 1"}
-C {lab_pin.sym} 1340 -1140 0 0 {name=p19 sig_type=std_logic lab=v_dd}
-C {lab_pin.sym} 1340 -780 0 0 {name=p20 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1580 -870 0 0 {name=C3
+C {devices/ammeter.sym} 2030 -280 1 0 {name=Vir1 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1930 -280 1 0 {name=Vif1 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 1980 -210 2 0 {name=Itest1 value="dc 0 ac 1"}
+C {devices/lab_pin.sym} 1340 -1140 0 0 {name=p19 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 1340 -780 0 0 {name=p20 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1580 -870 0 0 {name=C3
 value=50f}
-C {lab_wire.sym} 1100 -990 0 0 {name=p22 sig_type=std_logic lab=v_in}
-C {isource.sym} 1380 -1090 0 0 {name=I3 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {lab_wire.sym} 1380 -860 0 1 {name=p23 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 1100 -990 0 0 {name=p22 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 1380 -1090 0 0 {name=I3 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/lab_wire.sym} 1380 -860 0 1 {name=p23 sig_type=std_logic lab=v_ena}
 C {ota-5t.sym} 1340 -960 0 0 {name=x3}
-C {lab_pin.sym} 2100 -1140 0 0 {name=p26 sig_type=std_logic lab=v_dd}
-C {lab_pin.sym} 2100 -780 0 0 {name=p27 sig_type=std_logic lab=v_ss}
-C {capa.sym} 2340 -870 0 0 {name=C4
+C {devices/lab_pin.sym} 2100 -1140 0 0 {name=p26 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 2100 -780 0 0 {name=p27 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 2340 -870 0 0 {name=C4
 value=50f}
-C {lab_wire.sym} 1860 -990 0 0 {name=p29 sig_type=std_logic lab=v_in}
-C {isource.sym} 2140 -1090 0 0 {name=I4 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {lab_wire.sym} 2140 -860 0 1 {name=p30 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 1860 -990 0 0 {name=p29 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 2140 -1090 0 0 {name=I4 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/lab_wire.sym} 2140 -860 0 1 {name=p30 sig_type=std_logic lab=v_ena}
 C {ota-5t.sym} 2100 -960 0 0 {name=x4}
-C {isource.sym} 1100 -750 2 1 {name=Itest3 value="dc 0 ac 0"}
+C {devices/isource.sym} 1100 -750 2 1 {name=Itest3 value="dc 0 ac 0"}
 C {devices/vsource.sym} 1170 -840 3 0 {name=Vtest2 value="dc 0 ac 1"}
-C {lab_wire.sym} 1140 -800 2 0 {name=p24 sig_type=std_logic lab=vmeas1}
-C {ammeter.sym} 1270 -840 1 0 {name=Vimeas1 savecurrent=true spice_ignore=0}
-C {isource.sym} 1860 -750 2 1 {name=Itest2 value="dc 0 ac 1"}
+C {devices/lab_wire.sym} 1140 -800 2 0 {name=p24 sig_type=std_logic lab=vmeas1}
+C {devices/ammeter.sym} 1270 -840 1 0 {name=Vimeas1 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 1860 -750 2 1 {name=Itest2 value="dc 0 ac 1"}
 C {devices/vsource.sym} 1930 -840 3 0 {name=Vtest3 value="dc 0 ac 0"}
-C {lab_wire.sym} 1900 -800 2 0 {name=p25 sig_type=std_logic lab=vmeas2}
-C {ammeter.sym} 2030 -840 1 0 {name=Vimeas2 savecurrent=true spice_ignore=0}
+C {devices/lab_wire.sym} 1900 -800 2 0 {name=p25 sig_type=std_logic lab=vmeas2}
+C {devices/ammeter.sym} 2030 -840 1 0 {name=Vimeas2 savecurrent=true spice_ignore=0}

--- a/xschem/ota-5t_tb-noise.sch
+++ b/xschem/ota-5t_tb-noise.sch
@@ -101,20 +101,20 @@ C {devices/launcher.sym} 740 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {ota-5t.sym} 1050 -630 0 0 {name=xota}
 C {devices/vsource.sym} 600 -330 0 0 {name=Vss value=0}
 C {devices/gnd.sym} 600 -280 0 0 {name=l1 lab=GND}
-C {lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1300 -560 0 0 {name=C1
+C {devices/lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1300 -560 0 0 {name=C1
 value=50f}
-C {lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
+C {devices/lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
 C {devices/vsource.sym} 700 -540 0 0 {name=Vcm value="dc 0.8"}
-C {lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_cm}
-C {isource.sym} 1090 -780 0 0 {name=I0 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {vsource.sym} 1090 -430 0 0 {name=Venable value=1.5 savecurrent=false}
-C {spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
-C {spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
-C {spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
-C {lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_cm}
+C {devices/isource.sym} 1090 -780 0 0 {name=I0 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/vsource.sym} 1090 -430 0 0 {name=Venable value=1.5 savecurrent=false}
+C {devices/spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
+C {devices/spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
+C {devices/spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
+C {devices/lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
 C {devices/vsource.sym} 830 -600 0 0 {name=Vin value="dc 0 ac 1"}

--- a/xschem/ota-5t_tb-tran.sch
+++ b/xschem/ota-5t_tb-tran.sch
@@ -92,19 +92,19 @@ C {devices/launcher.sym} 500 -160 0 0 {name=h2
 descr="simulate" 
 tclcommand="xschem save; xschem netlist; xschem simulate"
 }
-C {lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {ota-5t.sym} 1050 -630 0 0 {name=xota}
 C {devices/vsource.sym} 600 -330 0 0 {name=Vss value=0}
 C {devices/gnd.sym} 600 -280 0 0 {name=l1 lab=GND}
-C {lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1300 -560 0 0 {name=C1
+C {devices/lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1300 -560 0 0 {name=C1
 value=50f}
-C {lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
+C {devices/lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
 C {devices/vsource.sym} 700 -540 0 0 {name=Vin value=0.8}
-C {lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_in}
-C {isource.sym} 1090 -780 0 0 {name=I0 value="dc 0 pwl(0 0 1.1u 0 1.2u 20u)"}
-C {vsource.sym} 1090 -430 0 0 {name=Venable value="dc 0 pwl(0 0 1u 0 1.1u 1.5)" savecurrent=false}
-C {spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
-C {spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
-C {spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
-C {lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 1090 -780 0 0 {name=I0 value="dc 0 pwl(0 0 1.1u 0 1.2u 20u)"}
+C {devices/vsource.sym} 1090 -430 0 0 {name=Venable value="dc 0 pwl(0 0 1u 0 1.1u 1.5)" savecurrent=false}
+C {devices/spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
+C {devices/spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
+C {devices/spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
+C {devices/lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}

--- a/xschem/ota-differential_tb-loopgain.sch
+++ b/xschem/ota-differential_tb-loopgain.sch
@@ -600,11 +600,11 @@ C {devices/launcher.sym} 2950 -2980 0 0 {name=h3
 descr="Annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {vdd.sym} 3760 -2200 0 0 {name=l7 lab=VDD}
-C {vdd.sym} 2340 -2560 0 0 {name=l8 lab=VDD}
+C {devices/vdd.sym} 3760 -2200 0 0 {name=l7 lab=VDD}
+C {devices/vdd.sym} 2340 -2560 0 0 {name=l8 lab=VDD}
 C {devices/gnd.sym} 2340 -2280 0 0 {name=l9 lab=GND}
-C {lab_pin.sym} 2740 -2400 0 1 {name=p3 sig_type=std_logic lab=voutp1}
-C {lab_pin.sym} 2740 -2440 0 1 {name=p4 sig_type=std_logic lab=voutn1}
+C {devices/lab_pin.sym} 2740 -2400 0 1 {name=p3 sig_type=std_logic lab=voutp1}
+C {devices/lab_pin.sym} 2740 -2440 0 1 {name=p4 sig_type=std_logic lab=voutn1}
 C {devices/lab_pin.sym} 1640 -2560 0 0 {name=l10 sig_type=std_logic lab=vinp1}
 C {devices/lab_pin.sym} 1640 -2280 0 0 {name=l11 sig_type=std_logic lab=vinn1
 }
@@ -641,32 +641,32 @@ C {devices/lab_pin.sym} 2670 -2630 0 0 {name=l23 sig_type=std_logic lab=voutp1
 }
 C {devices/vsource.sym} 1320 -2350 0 0 {name=vind1 value="dc 0 ac 1"
 }
-C {res.sym} 2270 -2740 1 0 {name=R2a
+C {devices/res.sym} 2270 -2740 1 0 {name=R2a
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {res.sym} 2270 -2100 1 0 {name=R2b
+C {devices/res.sym} 2270 -2100 1 0 {name=R2b
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {capa.sym} 2270 -2660 1 0 {name=C2a
+C {devices/capa.sym} 2270 -2660 1 0 {name=C2a
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 2270 -2180 1 1 {name=C2b
+C {devices/capa.sym} 2270 -2180 1 1 {name=C2b
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 1930 -2540 1 0 {name=C1a
+C {devices/capa.sym} 1930 -2540 1 0 {name=C1a
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 1930 -2300 1 0 {name=C1b
+C {devices/capa.sym} 1930 -2300 1 0 {name=C1b
 m=1
 value=1p
 footprint=1206
@@ -710,10 +710,10 @@ m=1
 value=5f
 footprint=1206
 device="ceramic capacitor"}
-C {vdd.sym} 1840 -1760 0 0 {name=l27 lab=VDD}
+C {devices/vdd.sym} 1840 -1760 0 0 {name=l27 lab=VDD}
 C {devices/gnd.sym} 1840 -1480 0 0 {name=l29 lab=GND}
-C {lab_pin.sym} 2240 -1600 0 1 {name=p1 sig_type=std_logic lab=voutp2}
-C {lab_pin.sym} 2240 -1640 0 1 {name=p2 sig_type=std_logic lab=voutn2}
+C {devices/lab_pin.sym} 2240 -1600 0 1 {name=p1 sig_type=std_logic lab=voutp2}
+C {devices/lab_pin.sym} 2240 -1640 0 1 {name=p2 sig_type=std_logic lab=voutn2}
 C {devices/lab_pin.sym} 1740 -1620 0 0 {name=l31 sig_type=std_logic lab=Vcm}
 C {devices/lab_pin.sym} 1860 -1740 2 0 {name=l34 sig_type=std_logic lab=amp_en}
 C {devices/capa.sym} 2200 -1490 0 0 {name=C5
@@ -729,32 +729,32 @@ C {devices/lab_pin.sym} 2430 -1600 2 1 {name=l43 sig_type=std_logic lab=voutn2
 }
 C {devices/lab_pin.sym} 2430 -1640 0 0 {name=l44 sig_type=std_logic lab=voutp2
 }
-C {res.sym} 1770 -1940 1 0 {name=R1
+C {devices/res.sym} 1770 -1940 1 0 {name=R1
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {res.sym} 1770 -1300 1 0 {name=R2
+C {devices/res.sym} 1770 -1300 1 0 {name=R2
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {capa.sym} 1770 -1860 1 0 {name=C6
+C {devices/capa.sym} 1770 -1860 1 0 {name=C6
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 1770 -1380 1 1 {name=C7
+C {devices/capa.sym} 1770 -1380 1 1 {name=C7
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 1430 -1740 1 0 {name=C9
+C {devices/capa.sym} 1430 -1740 1 0 {name=C9
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 1430 -1500 1 0 {name=C10
+C {devices/capa.sym} 1430 -1500 1 0 {name=C10
 m=1
 value=1p
 footprint=1206
@@ -765,10 +765,10 @@ m=1
 value=5f
 footprint=1206
 device="ceramic capacitor"}
-C {vdd.sym} 1840 -1020 0 0 {name=l50 lab=VDD}
+C {devices/vdd.sym} 1840 -1020 0 0 {name=l50 lab=VDD}
 C {devices/gnd.sym} 1840 -740 0 0 {name=l51 lab=GND}
-C {lab_pin.sym} 2240 -860 0 1 {name=p5 sig_type=std_logic lab=voutp3}
-C {lab_pin.sym} 2240 -900 0 1 {name=p6 sig_type=std_logic lab=voutn3}
+C {devices/lab_pin.sym} 2240 -860 0 1 {name=p5 sig_type=std_logic lab=voutp3}
+C {devices/lab_pin.sym} 2240 -900 0 1 {name=p6 sig_type=std_logic lab=voutn3}
 C {devices/lab_pin.sym} 1740 -880 0 0 {name=l52 sig_type=std_logic lab=Vcm}
 C {devices/lab_pin.sym} 1860 -1000 2 0 {name=l55 sig_type=std_logic lab=amp_en}
 C {devices/capa.sym} 2200 -750 0 0 {name=C14
@@ -784,37 +784,37 @@ C {devices/lab_pin.sym} 2430 -860 2 1 {name=l59 sig_type=std_logic lab=voutn3
 }
 C {devices/lab_pin.sym} 2430 -900 0 0 {name=l60 sig_type=std_logic lab=voutp3
 }
-C {res.sym} 1770 -1200 1 0 {name=R3
+C {devices/res.sym} 1770 -1200 1 0 {name=R3
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {res.sym} 1770 -560 1 0 {name=R4
+C {devices/res.sym} 1770 -560 1 0 {name=R4
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {capa.sym} 1770 -1120 1 0 {name=C15
+C {devices/capa.sym} 1770 -1120 1 0 {name=C15
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 1770 -640 1 1 {name=C16
+C {devices/capa.sym} 1770 -640 1 1 {name=C16
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 1430 -1000 1 0 {name=C17
+C {devices/capa.sym} 1430 -1000 1 0 {name=C17
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 1430 -760 1 0 {name=C18
+C {devices/capa.sym} 1430 -760 1 0 {name=C18
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {title.sym} 180 -60 0 0 {name=l2 author="Simon Dorrer"}
+C {devices/title.sym} 180 -60 0 0 {name=l2 author="Simon Dorrer"}
 C {devices/lab_pin.sym} 1320 -1620 0 0 {name=l65 sig_type=std_logic lab=Vcm}
 C {devices/lab_pin.sym} 1320 -880 0 0 {name=l32 sig_type=std_logic lab=Vcm}
 C {devices/lab_pin.sym} 2260 -1890 0 1 {name=l48 sig_type=std_logic lab=vf2}
@@ -834,18 +834,18 @@ C {devices/lab_pin.sym} 2430 -1860 0 0 {name=l61 sig_type=std_logic lab=vrp2
 
 }
 C {devices/vsource.sym} 1630 -1660 1 1 {name=Vtestp2 value="dc 0 ac 1"}
-C {lab_wire.sym} 1720 -1660 0 0 {name=p9 sig_type=std_logic lab=vfp2}
-C {lab_wire.sym} 1560 -1660 0 0 {name=p13 sig_type=std_logic lab=vrp2}
+C {devices/lab_wire.sym} 1720 -1660 0 0 {name=p9 sig_type=std_logic lab=vfp2}
+C {devices/lab_wire.sym} 1560 -1660 0 0 {name=p13 sig_type=std_logic lab=vrp2}
 C {devices/vsource.sym} 1630 -1580 1 0 {name=Vtestn2 value="dc 0 ac -1"}
-C {lab_wire.sym} 1720 -1580 0 0 {name=p10 sig_type=std_logic lab=vfn2}
-C {lab_wire.sym} 1560 -1580 0 0 {name=p11 sig_type=std_logic lab=vrn2}
-C {ammeter.sym} 1570 -940 3 1 {name=Virp3 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1670 -940 3 1 {name=Vifp3 savecurrent=true spice_ignore=0}
-C {isource.sym} 1620 -770 2 1 {name=Itestn3 value="dc 0 ac -1"}
+C {devices/lab_wire.sym} 1720 -1580 0 0 {name=p10 sig_type=std_logic lab=vfn2}
+C {devices/lab_wire.sym} 1560 -1580 0 0 {name=p11 sig_type=std_logic lab=vrn2}
+C {devices/ammeter.sym} 1570 -940 3 1 {name=Virp3 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1670 -940 3 1 {name=Vifp3 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 1620 -770 2 1 {name=Itestn3 value="dc 0 ac -1"}
 C {devices/gnd.sym} 1620 -720 0 0 {name=l62 lab=GND}
-C {ammeter.sym} 1570 -820 3 0 {name=Virn3 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1670 -820 3 0 {name=Vifn3 savecurrent=true spice_ignore=0}
-C {isource.sym} 1620 -990 0 0 {name=Itestp3 value="dc 0 ac 1"}
+C {devices/ammeter.sym} 1570 -820 3 0 {name=Virn3 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1670 -820 3 0 {name=Vifn3 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 1620 -990 0 0 {name=Itestp3 value="dc 0 ac 1"}
 C {devices/gnd.sym} 1620 -1040 2 0 {name=l63 lab=GND}
 C {devices/gnd.sym} 3480 -1400 0 0 {name=l64 lab=GND}
 C {devices/capa.sym} 3480 -1490 0 0 {name=C11
@@ -853,10 +853,10 @@ m=1
 value=5f
 footprint=1206
 device="ceramic capacitor"}
-C {vdd.sym} 3220 -1760 0 0 {name=l66 lab=VDD}
+C {devices/vdd.sym} 3220 -1760 0 0 {name=l66 lab=VDD}
 C {devices/gnd.sym} 3220 -1480 0 0 {name=l67 lab=GND}
-C {lab_pin.sym} 3620 -1600 0 1 {name=p7 sig_type=std_logic lab=voutp4}
-C {lab_pin.sym} 3620 -1640 0 1 {name=p8 sig_type=std_logic lab=voutn4}
+C {devices/lab_pin.sym} 3620 -1600 0 1 {name=p7 sig_type=std_logic lab=voutp4}
+C {devices/lab_pin.sym} 3620 -1640 0 1 {name=p8 sig_type=std_logic lab=voutn4}
 C {devices/lab_pin.sym} 3120 -1620 0 0 {name=l68 sig_type=std_logic lab=Vcm}
 C {devices/lab_pin.sym} 3240 -1740 2 0 {name=l69 sig_type=std_logic lab=amp_en}
 C {devices/capa.sym} 3580 -1490 0 0 {name=C12
@@ -872,32 +872,32 @@ C {devices/lab_pin.sym} 3790 -1600 2 1 {name=l73 sig_type=std_logic lab=voutn4
 }
 C {devices/lab_pin.sym} 3790 -1640 0 0 {name=l74 sig_type=std_logic lab=voutp4
 }
-C {res.sym} 3150 -1940 1 0 {name=R5
+C {devices/res.sym} 3150 -1940 1 0 {name=R5
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {res.sym} 3150 -1300 1 0 {name=R6
+C {devices/res.sym} 3150 -1300 1 0 {name=R6
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {capa.sym} 3150 -1860 1 0 {name=C19
+C {devices/capa.sym} 3150 -1860 1 0 {name=C19
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 3150 -1380 1 1 {name=C20
+C {devices/capa.sym} 3150 -1380 1 1 {name=C20
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 2810 -1740 1 0 {name=C21
+C {devices/capa.sym} 2810 -1740 1 0 {name=C21
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 2810 -1500 1 0 {name=C22
+C {devices/capa.sym} 2810 -1500 1 0 {name=C22
 m=1
 value=1p
 footprint=1206
@@ -908,10 +908,10 @@ m=1
 value=5f
 footprint=1206
 device="ceramic capacitor"}
-C {vdd.sym} 3220 -1020 0 0 {name=l76 lab=VDD}
+C {devices/vdd.sym} 3220 -1020 0 0 {name=l76 lab=VDD}
 C {devices/gnd.sym} 3220 -740 0 0 {name=l77 lab=GND}
-C {lab_pin.sym} 3620 -860 0 1 {name=p12 sig_type=std_logic lab=voutp5}
-C {lab_pin.sym} 3620 -900 0 1 {name=p14 sig_type=std_logic lab=voutn5}
+C {devices/lab_pin.sym} 3620 -860 0 1 {name=p12 sig_type=std_logic lab=voutp5}
+C {devices/lab_pin.sym} 3620 -900 0 1 {name=p14 sig_type=std_logic lab=voutn5}
 C {devices/lab_pin.sym} 3120 -880 0 0 {name=l78 sig_type=std_logic lab=Vcm}
 C {devices/lab_pin.sym} 3240 -1000 2 0 {name=l79 sig_type=std_logic lab=amp_en}
 C {devices/capa.sym} 3580 -750 0 0 {name=C24
@@ -927,32 +927,32 @@ C {devices/lab_pin.sym} 3790 -860 2 1 {name=l83 sig_type=std_logic lab=voutn5
 }
 C {devices/lab_pin.sym} 3790 -900 0 0 {name=l84 sig_type=std_logic lab=voutp5
 }
-C {res.sym} 3150 -1200 1 0 {name=R7
+C {devices/res.sym} 3150 -1200 1 0 {name=R7
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {res.sym} 3150 -560 1 0 {name=R8
+C {devices/res.sym} 3150 -560 1 0 {name=R8
 value=10k
 footprint=1206
 device=resistor
 m=1}
-C {capa.sym} 3150 -1120 1 0 {name=C25
+C {devices/capa.sym} 3150 -1120 1 0 {name=C25
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 3150 -640 1 1 {name=C26
+C {devices/capa.sym} 3150 -640 1 1 {name=C26
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 2810 -1000 1 0 {name=C27
+C {devices/capa.sym} 2810 -1000 1 0 {name=C27
 m=1
 value=1p
 footprint=1206
 device="ceramic capacitor"}
-C {capa.sym} 2810 -760 1 0 {name=C28
+C {devices/capa.sym} 2810 -760 1 0 {name=C28
 m=1
 value=1p
 footprint=1206
@@ -960,25 +960,25 @@ device="ceramic capacitor"}
 C {devices/lab_pin.sym} 2700 -1620 0 0 {name=l85 sig_type=std_logic lab=Vcm}
 C {devices/lab_pin.sym} 2700 -880 0 0 {name=l86 sig_type=std_logic lab=Vcm}
 C {devices/vsource.sym} 3010 -1680 1 1 {name=Vtestp4 value="dc 0 ac 1"}
-C {ammeter.sym} 2930 -1680 3 0 {name=Vimeasp4 savecurrent=true spice_ignore=0}
-C {isource.sym} 3080 -1730 0 0 {name=Itestp4 value="dc 0 ac 0"}
+C {devices/ammeter.sym} 2930 -1680 3 0 {name=Vimeasp4 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 3080 -1730 0 0 {name=Itestp4 value="dc 0 ac 0"}
 C {devices/gnd.sym} 3080 -1780 2 0 {name=l88 lab=GND}
-C {ammeter.sym} 2930 -1560 3 0 {name=Vimeasn4 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 2930 -1560 3 0 {name=Vimeasn4 savecurrent=true spice_ignore=0}
 C {devices/vsource.sym} 3010 -1560 1 0 {name=Vtestn4 value="dc 0 ac -1"}
-C {lab_wire.sym} 3080 -1660 2 1 {name=p16 sig_type=std_logic lab=vmeasp4}
-C {isource.sym} 3080 -1510 2 1 {name=Itestn4 value="dc 0 ac 0"}
+C {devices/lab_wire.sym} 3080 -1660 2 1 {name=p16 sig_type=std_logic lab=vmeasp4}
+C {devices/isource.sym} 3080 -1510 2 1 {name=Itestn4 value="dc 0 ac 0"}
 C {devices/gnd.sym} 3080 -1460 0 0 {name=l89 lab=GND}
-C {lab_wire.sym} 3080 -1580 0 0 {name=p15 sig_type=std_logic lab=vmeasn4}
-C {ammeter.sym} 2930 -820 3 0 {name=Vimeasn5 savecurrent=true spice_ignore=0}
+C {devices/lab_wire.sym} 3080 -1580 0 0 {name=p15 sig_type=std_logic lab=vmeasn4}
+C {devices/ammeter.sym} 2930 -820 3 0 {name=Vimeasn5 savecurrent=true spice_ignore=0}
 C {devices/vsource.sym} 3010 -820 1 0 {name=Vtestn5 value="dc 0 ac 0"}
-C {isource.sym} 3080 -770 2 1 {name=Itestn5 value="dc 0 ac -1"}
+C {devices/isource.sym} 3080 -770 2 1 {name=Itestn5 value="dc 0 ac -1"}
 C {devices/gnd.sym} 3080 -720 0 0 {name=l87 lab=GND}
-C {lab_wire.sym} 3080 -840 0 0 {name=p17 sig_type=std_logic lab=vmeasn5}
+C {devices/lab_wire.sym} 3080 -840 0 0 {name=p17 sig_type=std_logic lab=vmeasn5}
 C {devices/vsource.sym} 3010 -940 1 1 {name=Vtestp5 value="dc 0 ac 0"}
-C {ammeter.sym} 2930 -940 3 0 {name=Vimeasp5 savecurrent=true spice_ignore=0}
-C {isource.sym} 3080 -990 0 0 {name=Itestp5 value="dc 0 ac 1"}
+C {devices/ammeter.sym} 2930 -940 3 0 {name=Vimeasp5 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 3080 -990 0 0 {name=Itestp5 value="dc 0 ac 1"}
 C {devices/gnd.sym} 3080 -1040 2 0 {name=l90 lab=GND}
-C {lab_wire.sym} 3080 -920 2 1 {name=p18 sig_type=std_logic lab=vmeasp5}
+C {devices/lab_wire.sym} 3080 -920 2 1 {name=p18 sig_type=std_logic lab=vmeasp5}
 C {devices/lab_pin.sym} 3860 -1890 0 1 {name=l91 sig_type=std_logic lab=vmeas4}
 C {devices/vcvs.sym} 3860 -1840 0 0 {name=E12 value=0.5}
 C {devices/gnd.sym} 3860 -1780 0 0 {name=l92 lab=GND}

--- a/xschem/ota-improved.sch
+++ b/xschem/ota-improved.sch
@@ -508,12 +508,12 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {ipin.sym} 150 -600 0 0 {name=p1 lab=ibias_5u}
-C {iopin.sym} 150 -1520 0 1 {name=p2 lab=vdd}
-C {iopin.sym} 150 -170 0 1 {name=p3 lab=vss}
-C {ipin.sym} 150 -770 0 0 {name=p4 lab=vinp}
-C {ipin.sym} 150 -680 0 0 {name=p5 lab=vinn}
-C {opin.sym} 1980 -1180 0 0 {name=p6 lab=vout}
+C {devices/ipin.sym} 150 -600 0 0 {name=p1 lab=ibias_5u}
+C {devices/iopin.sym} 150 -1520 0 1 {name=p2 lab=vdd}
+C {devices/iopin.sym} 150 -170 0 1 {name=p3 lab=vss}
+C {devices/ipin.sym} 150 -770 0 0 {name=p4 lab=vinp}
+C {devices/ipin.sym} 150 -680 0 0 {name=p5 lab=vinn}
+C {devices/opin.sym} 1980 -1180 0 0 {name=p6 lab=vout}
 C {sg13g2_pr/sg13_lv_nmos.sym} 390 -220 0 0 {name=Mpd3
 l=0.13u
 w=1u
@@ -530,7 +530,7 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {ipin.sym} 150 -300 0 0 {name=p7 lab=d_ena}
+C {devices/ipin.sym} 150 -300 0 0 {name=p7 lab=d_ena}
 C {sg13g2_pr/sg13_lv_nmos.sym} 690 -500 0 0 {name=Mpd6
 l=0.13u
 w=1u
@@ -539,10 +539,10 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {lab_wire.sym} 460 -280 0 0 {name=p8 sig_type=std_logic lab=ena_n}
-C {lab_wire.sym} 880 -320 0 0 {name=p9 sig_type=std_logic lab=gate}
-C {lab_wire.sym} 1660 -1370 0 0 {name=p10 sig_type=std_logic lab=gate_p}
-C {lab_wire.sym} 1720 -720 0 0 {name=p11 sig_type=std_logic lab=tail}
+C {devices/lab_wire.sym} 460 -280 0 0 {name=p8 sig_type=std_logic lab=ena_n}
+C {devices/lab_wire.sym} 880 -320 0 0 {name=p9 sig_type=std_logic lab=gate}
+C {devices/lab_wire.sym} 1660 -1370 0 0 {name=p10 sig_type=std_logic lab=gate_p}
+C {devices/lab_wire.sym} 1720 -720 0 0 {name=p11 sig_type=std_logic lab=tail}
 C {sg13g2_pr/sg13_lv_nmos.sym} 1810 -890 0 1 {name=M2c
 l=0.5u
 w=1u
@@ -583,7 +583,7 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {lab_wire.sym} 1660 -1290 0 0 {name=p13 sig_type=std_logic lab=gate_pc}
+C {devices/lab_wire.sym} 1660 -1290 0 0 {name=p13 sig_type=std_logic lab=gate_pc}
 C {sg13g2_pr/sg13_lv_pmos.sym} 1690 -1470 0 0 {name=Mpd8
 l=0.13u
 w=1u
@@ -624,13 +624,13 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {lab_wire.sym} 1580 -1060 0 0 {name=p14 sig_type=std_logic lab=dp_casc}
-C {ngspice_probe.sym} 1490 -820 0 0 {name=r6}
-C {ngspice_probe.sym} 1790 -820 0 0 {name=r7}
-C {ngspice_probe.sym} 1490 -1320 0 0 {name=r9}
-C {ngspice_probe.sym} 1790 -1320 0 0 {name=r10}
-C {ammeter.sym} 980 -900 0 1 {name=Vmeas savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1610 -510 0 1 {name=Vmeas1 savecurrent=true spice_ignore=0}
+C {devices/lab_wire.sym} 1580 -1060 0 0 {name=p14 sig_type=std_logic lab=dp_casc}
+C {devices/ngspice_probe.sym} 1490 -820 0 0 {name=r6}
+C {devices/ngspice_probe.sym} 1790 -820 0 0 {name=r7}
+C {devices/ngspice_probe.sym} 1490 -1320 0 0 {name=r9}
+C {devices/ngspice_probe.sym} 1790 -1320 0 0 {name=r10}
+C {devices/ammeter.sym} 980 -900 0 1 {name=Vmeas savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1610 -510 0 1 {name=Vmeas1 savecurrent=true spice_ignore=0}
 C {sg13g2_pr/sg13_lv_nmos.sym} 230 -220 0 0 {name=Mpd1
 l=0.13u
 w=1u
@@ -646,8 +646,8 @@ m=1
 model=sg13_lv_pmos
 spiceprefix=X
 }
-C {lab_wire.sym} 480 -300 0 0 {name=p15 sig_type=std_logic lab=ena}
-C {ammeter.sym} 330 -600 3 1 {name=Vmeas4 savecurrent=true spice_ignore=0}
+C {devices/lab_wire.sym} 480 -300 0 0 {name=p15 sig_type=std_logic lab=ena}
+C {devices/ammeter.sym} 330 -600 3 1 {name=Vmeas4 savecurrent=true spice_ignore=0}
 C {sg13g2_pr/sg13_lv_nmos.sym} 1920 -220 0 0 {name=Mpd11
 l=0.13u
 w=0.5u
@@ -656,7 +656,7 @@ m=1
 model=sg13_lv_nmos
 spiceprefix=X
 }
-C {lab_wire.sym} 1890 -220 0 0 {name=p16 sig_type=std_logic lab=ena_n}
+C {devices/lab_wire.sym} 1890 -220 0 0 {name=p16 sig_type=std_logic lab=ena_n}
 C {sg13g2_pr/sg13_lv_nmos.sym} 1250 -830 0 1 {name=M10_4
 l=0.5u
 w=1u

--- a/xschem/ota-improved_tb-ac.sch
+++ b/xschem/ota-improved_tb-ac.sch
@@ -104,19 +104,19 @@ C {devices/launcher.sym} 740 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {ota-improved.sym} 1050 -630 0 0 {name=xota}
 C {devices/vsource.sym} 600 -330 0 0 {name=Vss value=0}
 C {devices/gnd.sym} 600 -280 0 0 {name=l1 lab=GND}
-C {lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1300 -560 0 0 {name=C1
+C {devices/lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1300 -560 0 0 {name=C1
 value=50f}
-C {lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
+C {devices/lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
 C {devices/vsource.sym} 700 -540 0 0 {name=Vin value="dc 0.8 ac 1"}
-C {lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_in}
-C {isource.sym} 1090 -780 0 0 {name=I0 value=5u pwl(0 0 10u 0 11u 5u)"}
-C {vsource.sym} 1090 -430 0 0 {name=Venable value=1.5 savecurrent=false}
-C {spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
-C {spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
-C {spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
-C {lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 1090 -780 0 0 {name=I0 value=5u pwl(0 0 10u 0 11u 5u)"}
+C {devices/vsource.sym} 1090 -430 0 0 {name=Venable value=1.5 savecurrent=false}
+C {devices/spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
+C {devices/spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
+C {devices/spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
+C {devices/lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}

--- a/xschem/ota-improved_tb-loopgain.sch
+++ b/xschem/ota-improved_tb-loopgain.sch
@@ -183,58 +183,58 @@ tclcommand="xschem save; xschem netlist; xschem simulate"
 }
 C {devices/vsource.sym} 720 -190 0 0 {name=Vdd value=1.5}
 C {devices/gnd.sym} 720 -140 0 0 {name=l3 lab=GND}
-C {lab_pin.sym} 720 -240 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 720 -240 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {devices/vsource.sym} 880 -190 0 0 {name=Vss value=0}
 C {devices/gnd.sym} 880 -140 0 0 {name=l1 lab=GND}
-C {lab_pin.sym} 880 -240 0 0 {name=p1 sig_type=std_logic lab=v_ss}
+C {devices/lab_pin.sym} 880 -240 0 0 {name=p1 sig_type=std_logic lab=v_ss}
 C {devices/vsource.sym} 720 -350 0 0 {name=Vin value="dc 0.75"}
-C {lab_wire.sym} 720 -400 0 0 {name=p4 sig_type=std_logic lab=v_in}
-C {vsource.sym} 880 -350 0 0 {name=Venable value=1.5 savecurrent=false}
-C {lab_wire.sym} 880 -400 0 1 {name=p8 sig_type=std_logic lab=v_ena}
-C {lab_pin.sym} 1340 -580 0 0 {name=p5 sig_type=std_logic lab=v_dd}
-C {lab_pin.sym} 1340 -220 0 0 {name=p6 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1580 -310 0 0 {name=C2
+C {devices/lab_wire.sym} 720 -400 0 0 {name=p4 sig_type=std_logic lab=v_in}
+C {devices/vsource.sym} 880 -350 0 0 {name=Venable value=1.5 savecurrent=false}
+C {devices/lab_wire.sym} 880 -400 0 1 {name=p8 sig_type=std_logic lab=v_ena}
+C {devices/lab_pin.sym} 1340 -580 0 0 {name=p5 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 1340 -220 0 0 {name=p6 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1580 -310 0 0 {name=C2
 value=50f}
-C {lab_wire.sym} 1100 -430 0 0 {name=p9 sig_type=std_logic lab=v_in}
-C {isource.sym} 1380 -530 0 0 {name=I1 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {lab_wire.sym} 1380 -300 0 1 {name=p10 sig_type=std_logic lab=v_ena}
-C {lab_pin.sym} 720 -300 0 0 {name=p11 sig_type=std_logic lab=v_ss}
-C {lab_pin.sym} 880 -300 0 0 {name=p12 sig_type=std_logic lab=v_ss}
+C {devices/lab_wire.sym} 1100 -430 0 0 {name=p9 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 1380 -530 0 0 {name=I1 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/lab_wire.sym} 1380 -300 0 1 {name=p10 sig_type=std_logic lab=v_ena}
+C {devices/lab_pin.sym} 720 -300 0 0 {name=p11 sig_type=std_logic lab=v_ss}
+C {devices/lab_pin.sym} 880 -300 0 0 {name=p12 sig_type=std_logic lab=v_ss}
 C {devices/vsource.sym} 1210 -280 3 0 {name=Vtest1 value="dc 0 ac 1"}
-C {lab_wire.sym} 1140 -280 0 0 {name=p3 sig_type=std_logic lab=vf1}
-C {lab_wire.sym} 1290 -280 0 0 {name=p13 sig_type=std_logic lab=vr1}
-C {lab_pin.sym} 2100 -580 0 0 {name=p14 sig_type=std_logic lab=v_dd}
-C {lab_pin.sym} 2100 -220 0 0 {name=p15 sig_type=std_logic lab=v_ss}
-C {capa.sym} 2340 -310 0 0 {name=C1
+C {devices/lab_wire.sym} 1140 -280 0 0 {name=p3 sig_type=std_logic lab=vf1}
+C {devices/lab_wire.sym} 1290 -280 0 0 {name=p13 sig_type=std_logic lab=vr1}
+C {devices/lab_pin.sym} 2100 -580 0 0 {name=p14 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 2100 -220 0 0 {name=p15 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 2340 -310 0 0 {name=C1
 value=50f}
-C {lab_wire.sym} 1860 -430 0 0 {name=p17 sig_type=std_logic lab=v_in}
-C {isource.sym} 2140 -530 0 0 {name=I2 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {lab_wire.sym} 2140 -300 0 1 {name=p18 sig_type=std_logic lab=v_ena}
-C {ammeter.sym} 2030 -280 1 0 {name=Vir1 savecurrent=true spice_ignore=0}
-C {ammeter.sym} 1930 -280 1 0 {name=Vif1 savecurrent=true spice_ignore=0}
-C {isource.sym} 1980 -210 2 0 {name=Itest1 value="dc 0 ac 1"}
-C {lab_pin.sym} 1340 -1140 0 0 {name=p19 sig_type=std_logic lab=v_dd}
-C {lab_pin.sym} 1340 -780 0 0 {name=p20 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1580 -870 0 0 {name=C3
+C {devices/lab_wire.sym} 1860 -430 0 0 {name=p17 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 2140 -530 0 0 {name=I2 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/lab_wire.sym} 2140 -300 0 1 {name=p18 sig_type=std_logic lab=v_ena}
+C {devices/ammeter.sym} 2030 -280 1 0 {name=Vir1 savecurrent=true spice_ignore=0}
+C {devices/ammeter.sym} 1930 -280 1 0 {name=Vif1 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 1980 -210 2 0 {name=Itest1 value="dc 0 ac 1"}
+C {devices/lab_pin.sym} 1340 -1140 0 0 {name=p19 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 1340 -780 0 0 {name=p20 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1580 -870 0 0 {name=C3
 value=50f}
-C {lab_wire.sym} 1100 -990 0 0 {name=p22 sig_type=std_logic lab=v_in}
-C {isource.sym} 1380 -1090 0 0 {name=I3 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {lab_wire.sym} 1380 -860 0 1 {name=p23 sig_type=std_logic lab=v_ena}
-C {lab_pin.sym} 2100 -1140 0 0 {name=p26 sig_type=std_logic lab=v_dd}
-C {lab_pin.sym} 2100 -780 0 0 {name=p27 sig_type=std_logic lab=v_ss}
-C {capa.sym} 2340 -870 0 0 {name=C4
+C {devices/lab_wire.sym} 1100 -990 0 0 {name=p22 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 1380 -1090 0 0 {name=I3 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/lab_wire.sym} 1380 -860 0 1 {name=p23 sig_type=std_logic lab=v_ena}
+C {devices/lab_pin.sym} 2100 -1140 0 0 {name=p26 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 2100 -780 0 0 {name=p27 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 2340 -870 0 0 {name=C4
 value=50f}
-C {lab_wire.sym} 1860 -990 0 0 {name=p29 sig_type=std_logic lab=v_in}
-C {isource.sym} 2140 -1090 0 0 {name=I4 value=20u pwl(0 0 10u 0 11u 20u)"}
-C {lab_wire.sym} 2140 -860 0 1 {name=p30 sig_type=std_logic lab=v_ena}
-C {isource.sym} 1100 -750 2 1 {name=Itest3 value="dc 0 ac 0"}
+C {devices/lab_wire.sym} 1860 -990 0 0 {name=p29 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 2140 -1090 0 0 {name=I4 value=20u pwl(0 0 10u 0 11u 20u)"}
+C {devices/lab_wire.sym} 2140 -860 0 1 {name=p30 sig_type=std_logic lab=v_ena}
+C {devices/isource.sym} 1100 -750 2 1 {name=Itest3 value="dc 0 ac 0"}
 C {devices/vsource.sym} 1170 -840 3 0 {name=Vtest2 value="dc 0 ac 1"}
-C {lab_wire.sym} 1140 -800 2 0 {name=p24 sig_type=std_logic lab=vmeas1}
-C {ammeter.sym} 1270 -840 1 0 {name=Vimeas1 savecurrent=true spice_ignore=0}
-C {isource.sym} 1860 -750 2 1 {name=Itest2 value="dc 0 ac 1"}
+C {devices/lab_wire.sym} 1140 -800 2 0 {name=p24 sig_type=std_logic lab=vmeas1}
+C {devices/ammeter.sym} 1270 -840 1 0 {name=Vimeas1 savecurrent=true spice_ignore=0}
+C {devices/isource.sym} 1860 -750 2 1 {name=Itest2 value="dc 0 ac 1"}
 C {devices/vsource.sym} 1930 -840 3 0 {name=Vtest3 value="dc 0 ac 0"}
-C {lab_wire.sym} 1900 -800 2 0 {name=p25 sig_type=std_logic lab=vmeas2}
-C {ammeter.sym} 2030 -840 1 0 {name=Vimeas2 savecurrent=true spice_ignore=0}
+C {devices/lab_wire.sym} 1900 -800 2 0 {name=p25 sig_type=std_logic lab=vmeas2}
+C {devices/ammeter.sym} 2030 -840 1 0 {name=Vimeas2 savecurrent=true spice_ignore=0}
 C {ota-improved.sym} 1340 -400 0 0 {name=x1}
 C {ota-improved.sym} 2100 -400 0 0 {name=x2}
 C {ota-improved.sym} 1340 -960 0 0 {name=x3}

--- a/xschem/ota-improved_tb-noise.sch
+++ b/xschem/ota-improved_tb-noise.sch
@@ -104,20 +104,20 @@ C {devices/launcher.sym} 740 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {ota-improved.sym} 1050 -630 0 0 {name=xota}
 C {devices/vsource.sym} 600 -330 0 0 {name=Vss value=0}
 C {devices/gnd.sym} 600 -280 0 0 {name=l1 lab=GND}
-C {lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1300 -560 0 0 {name=C1
+C {devices/lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1300 -560 0 0 {name=C1
 value=50f}
-C {lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
+C {devices/lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
 C {devices/vsource.sym} 700 -540 0 0 {name=Vcm value="dc 0.8"}
-C {lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_cm}
-C {isource.sym} 1090 -780 0 0 {name=I0 value=5u pwl(0 0 10u 0 11u 20u)"}
-C {vsource.sym} 1090 -430 0 0 {name=Venable value=1.5 savecurrent=false}
-C {spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
-C {spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
-C {spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
-C {lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_cm}
+C {devices/isource.sym} 1090 -780 0 0 {name=I0 value=5u pwl(0 0 10u 0 11u 20u)"}
+C {devices/vsource.sym} 1090 -430 0 0 {name=Venable value=1.5 savecurrent=false}
+C {devices/spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
+C {devices/spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
+C {devices/spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
+C {devices/lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
 C {devices/vsource.sym} 830 -600 0 0 {name=Vin value="dc 0 ac 1"}

--- a/xschem/ota-improved_tb-tran.sch
+++ b/xschem/ota-improved_tb-tran.sch
@@ -91,22 +91,22 @@ C {devices/launcher.sym} 740 -160 0 0 {name=h3
 descr="annotate OP" 
 tclcommand="set show_hidden_texts 1; xschem annotate_op"
 }
-C {lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
+C {devices/lab_pin.sym} 520 -380 0 0 {name=p2 sig_type=std_logic lab=v_dd}
 C {ota-improved.sym} 1050 -630 0 0 {name=xota}
 C {devices/vsource.sym} 600 -330 0 0 {name=Vss value=0}
 C {devices/gnd.sym} 600 -280 0 0 {name=l1 lab=GND}
-C {lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
-C {capa.sym} 1300 -560 0 0 {name=C1
+C {devices/lab_pin.sym} 600 -380 0 0 {name=p1 sig_type=std_logic lab=v_ss}
+C {devices/capa.sym} 1300 -560 0 0 {name=C1
 value=50f}
-C {lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
+C {devices/lab_wire.sym} 1300 -630 0 0 {name=p3 sig_type=std_logic lab=v_out}
 C {devices/vsource.sym} 700 -540 0 0 {name=Vin value=0.8}
-C {lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_in}
-C {isource.sym} 1090 -780 0 0 {name=I0 value="dc 0 pwl(0 0 1.1u 0 1.2u 5u)"}
-C {vsource.sym} 1090 -430 0 0 {name=Venable value="dc 0 pwl(0 0 1u 0 1.1u 1.5)" savecurrent=false}
-C {spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
-C {spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
-C {spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
-C {lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
+C {devices/lab_wire.sym} 760 -660 0 0 {name=p4 sig_type=std_logic lab=v_in}
+C {devices/isource.sym} 1090 -780 0 0 {name=I0 value="dc 0 pwl(0 0 1.1u 0 1.2u 5u)"}
+C {devices/vsource.sym} 1090 -430 0 0 {name=Venable value="dc 0 pwl(0 0 1u 0 1.1u 1.5)" savecurrent=false}
+C {devices/spice_probe.sym} 820 -660 0 0 {name=p5 attrs=""}
+C {devices/spice_probe.sym} 1180 -630 0 0 {name=p6 attrs=""}
+C {devices/spice_probe.sym} 1090 -470 0 0 {name=p7 attrs=""}
+C {devices/lab_wire.sym} 1090 -530 0 0 {name=p8 sig_type=std_logic lab=v_ena}
 C {devices/code_shown.sym} 0 -170 0 0 {name=MODEL only_toplevel=true
 format="tcleval( @value )"
 value="


### PR DESCRIPTION
Currently the schematics use a mix of `xxx.sym` and `devices/xxx.sym` to refer to default devices from the xschem library.
This bulks edit them to always use the full `devices/xxx.sym`.