### PR TITLE
kT/C noise reference

### DIFF
--- a/content/_sec_mosfet_diode.qmd
+++ b/content/_sec_mosfet_diode.qmd
@@ -237,7 +237,7 @@ $$
 V_\mathrm{n,rms}^2 = \frac{k T}{C} 
 $$
 which is independent of $R$! This is a surprising result, and is the well-known $kT/C$ noise. 
-Intuitively, we could argue that the noise increases with larger $R$, but at the same time, the bandwidth decreases and therefore $R$ does not add additional noise.
+Intuitively, we could argue that the noise increases with larger $R$, but at the same time, the bandwidth decreases and therefore $R$ does not add additional noise. More detailed information and an intuitive explanation of $k T / C$ noise can be found in [@Sheikholeslami_2025_kTC].
 
 Side note: The shortest derivation of this formula involves the [equipartition theorem](https://en.wikipedia.org/wiki/Equipartition_theorem): Any system in thermal equilibrium has an energy of $kT/2$ per degree of freedom. This $RC$ system has one degree of freedom in the capacitor, and the stored energy in the capacitor is $CV_\mathrm{rms}^2/2$. Equating both energies we find that $V_\mathrm{rms}^2 = kT/C$.
 

--- a/references.bib
+++ b/references.bib
@@ -6,6 +6,16 @@
 
 %% Saved with string encoding Unicode (UTF-8) 
 
+@ARTICLE{Sheikholeslami_2025_kTC,
+  author={Sheikholeslami, Ali},
+  doi={10.1109/MSSC.2025.3582840},
+  journal={IEEE Solid-State Circuits Magazine},
+  number={3},
+  pages={29-31},
+  title={Noise and Distortion, Part IV [Circuit Intuitions]}, 
+  volume={17},
+  year={2025}}
+
 @online{Dorrer_Master_Thesis,
   author={Dorrer, Simon},
   title={An Open-Source Adaptive Event-Based ADC for Bio-Signal Acquisition in 130\,nm CMOS},


### PR DESCRIPTION
Paper: Ali Sheikholeslami continues his “Circuit Intuitions” series on Noise and Distortion with an intuitive explanation of kT/C noise (https://ieeexplore.ieee.org/document/11131359).