### PR TITLE
updated `_fig_curmir_highswing.qmd` (fix typo)

### DIFF
--- a/content/curmir_improved/_fig_curmir_highswing.qmd
+++ b/content/curmir_improved/_fig_curmir_highswing.qmd
@@ -26,7 +26,7 @@ with sd.Drawing(canvas='svg') as d:
 
     elm.Vdd()
     ibias = elm.SourceI().down().label(r'$I_\mathrm{bias}$')
-    res = elm.Resistor().down().label('$R_\mathrm{bias}$').color('blue')
+    res = elm.Resistor().down().label(r'$R_\mathrm{bias}$').color('blue')
     M3 = elm.AnalogNFet(offset_gate=False).drop('source').theta(0).label('$W_2/L_2$')
     M1 = elm.AnalogNFet(offset_gate=False).drop('source').theta(0).label('$W_1/L_1$')
     elm.Ground()


### PR DESCRIPTION
This should be gone now:

<img width="1151" height="489" alt="image" src="https://github.com/user-attachments/assets/f7933ef8-70cd-4fc8-9961-ad0bd664ea9d" />
