### PR TITLE
Run ngspice single-threaded by default in the simulation tests

### DIFF
--- a/xschem/run_simulation_tests.sh
+++ b/xschem/run_simulation_tests.sh
@@ -9,10 +9,11 @@
 #   3. scans the netlist and simulation logs for errors.
 #
 # Testbenches are run in parallel. The number of concurrent jobs defaults to
-# the CPU count (JOBS env var). To avoid overcommitting the CPU, each ngspice
-# instance is told how many threads to use via a per-testbench .spiceinit
-# (SPICE_THREADS env var, default = cores / JOBS). Each testbench gets its own
-# working sub-directory so parallel runs never clobber each other's files.
+# the CPU count (JOBS env var). Each ngspice runs single-threaded (SPICE_THREADS
+# env var, default 1), because these testbenches are too small to profit from
+# ngspice's OpenMP parallelism and several of them are slowed down badly by it.
+# Each testbench gets its own working sub-directory so parallel runs never
+# clobber each other's files.
 #
 # It is meant to run inside the IIC-OSIC-TOOLS Docker image (tag `latest`),
 # which provides xschem, ngspice and the IHP SG13G2 PDK. It also runs locally
@@ -44,10 +45,24 @@ NPROC="$(nproc 2>/dev/null || echo 4)"
 JOBS="${JOBS:-$NPROC}"
 
 # --- threads per ngspice instance ------------------------------------------
-# We already parallelise across testbenches, so each ngspice must stay
-# single-/few-threaded to avoid overcommitting the CPU (JOBS * threads cores).
-# Default: split the cores evenly over the running jobs (>=1).
-SPICE_THREADS="${SPICE_THREADS:-$(( NPROC / JOBS > 0 ? NPROC / JOBS : 1 ))}"
+# One thread per ngspice. Parallelism here comes from running testbenches
+# concurrently (JOBS), not from threading a single simulation: ngspice's OpenMP
+# parallelism speeds up the device model evaluation of *large* circuits, while
+# the testbenches in this repository are small (often a single transistor) and
+# some of them sweep parameters with tens of thousands of short `run` commands,
+# where per-run thread fork/join overhead is all the extra threads add.
+#
+# Measured in the IIC-OSIC-TOOLS container (nproc=9, JOBS=1, one testbench):
+#
+#   testbench                    1 thread   9 threads
+#   techsweep_sg13g2_lv_nmos        23 s      164 s
+#   bandgap_banba_tb                23 s       43 s
+#   current_mirror_variations        9 s       15 s
+#
+# The old default (cores / JOBS) therefore made a serial run several times
+# slower than a single-threaded one. Set SPICE_THREADS=<n> explicitly if a
+# testbench ever grows large enough to profit from threading.
+SPICE_THREADS="${SPICE_THREADS:-1}"
 export OMP_NUM_THREADS="$SPICE_THREADS"
 
 # --- PDK selection ---------------------------------------------------------


### PR DESCRIPTION
## Problem

`xschem/run_simulation_tests.sh` defaults the per-ngspice thread count to `cores / JOBS`, so a serialised run (`JOBS=1`) hands each ngspice all cores. The intent was to keep throughput up when the job pool is small — but for these testbenches it does the opposite.

ngspice's OpenMP parallelism speeds up device model evaluation of *large* circuits. The testbenches here are small (often a single transistor), and `techsweep_sg13g2_lv_{n,p}mos` sweep `L x Vg x Vd x Vb` and thus issue ~119k separate `run` commands each. Per-run thread fork/join overhead is all that extra threads add there — and it is the two techsweeps that dominate the suite runtime.

## Measurements

IIC-OSIC-TOOLS container (`hpretl/iic-osic-tools:latest`), `nproc=9`, `JOBS=1`, one testbench per run, each number reproduced twice:

| testbench | 1 thread | 9 threads |
| --- | --- | --- |
| `techsweep_sg13g2_lv_nmos` | 23 s | 164 s |
| `bandgap_banba_tb` | 23 s | 43 s |
| `current_mirror_variations` | 9 s | 15 s |

No testbench got faster with more threads.

## Change

Default `SPICE_THREADS` to 1 and take the parallelism from `JOBS`, which is what actually scales here. `SPICE_THREADS=<n>` still overrides it for testbenches that grow large enough to profit from threading. Header comment updated accordingly; no other behaviour changes.

## Verification

Full suite in the container with the new default: **31/31 passed in 41 s** (`JOBS=4`, `nproc=9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)