### PR TITLE
Clarify GBWP, gmb sign convention, Maxwell matrix, and OTA gain derivations

### DIFF
--- a/content/diode/_sec_mosfet_diode.qmd
+++ b/content/diode/_sec_mosfet_diode.qmd
@@ -162,16 +162,21 @@ $$
 \text{GBWP} = f_\mathrm{T,ol} = H_\mathrm{ol,dc} f_\mathrm{c,ol}
 $$
 
-If a frequency-independent negative feedback $G$ (e.g., a resistive divider) is applied to this open-loop system, the transit frequency changes to
+If a frequency-independent negative feedback $G$ (e.g., a resistive divider) is applied to this open-loop system, the closed-loop $-3\,\text{dB}$ cut-off frequency $f_\mathrm{c,cl}$ follows from the open-loop transit frequency and the feedback gain as
+$$
+f_\mathrm{c,cl} = H_\mathrm{ol,dc} f_\mathrm{c,ol} G = f_\mathrm{T,ol} G
+$$
+i.e. the bandwidth is extended by exactly the factor by which the gain is reduced. The **gain-bandwidth product is therefore preserved** by the feedback,
+$$
+H_\mathrm{cl,dc} f_\mathrm{c,cl} \approx \frac{1}{G} f_\mathrm{T,ol} G = f_\mathrm{T,ol},
+$$
+which is the reason the GBWP is such a useful figure of merit.
+
+What *does* change is the frequency at which the closed-loop gain itself crosses unity:
 $$
 f_\mathrm{T,cl} = f_\mathrm{T,ol} \sqrt{1 - G^2}
 $$
-Hence, the closed-loop transit frequency is slightly lower than the open-loop transit frequency $f_\mathrm{T,cl} < f_\mathrm{T,ol}$.
-
-The closed-loop $-3\,\text{dB}$ cut-off frequency $f_\mathrm{c,cl}$ can then be calculated from the open-loop transit frequency and the feedback gain.
-$$
-f_\mathrm{c,cl} = H_\mathrm{ol,DC} f_\mathrm{c,ol} G = f_\mathrm{T,ol} G
-$$
+Note that this is **not** the same quantity as the GBWP, even though the two coincide in the open-loop case --- this distinction is a common source of confusion. For weak feedback ($G \ll 1$) the closed-loop unity-gain frequency is only slightly lower than $f_\mathrm{T,ol}$, but for strong feedback it drops sharply, and for the unity-gain case $G = 1$ it vanishes altogether, simply because the closed-loop gain $H_\mathrm{cl} = H_\mathrm{ol}/(1+H_\mathrm{ol}) < 1$ never reaches unity in the first place. Keep this in mind for the MOSFET diode, where exactly this case $G = 1$ applies.
 
 This theory might be interesting when Middlebrook's and Tian's methods for loop gain analysis are later compared in the MOSFET diode testbench (see @fig-mosfet-diode-loopgain-tb).
 :::

--- a/content/first_steps/_sec_first_steps.qmd
+++ b/content/first_steps/_sec_first_steps.qmd
@@ -75,6 +75,8 @@ Throughout this material, we will largely stick to the following notation standa
 * An **ac (small-signal) quantity** (incremental quantity) has a lower-case variable name with a lower-case subscript, like $\gm$.
 * A **total quantity** (dc plus ac) is shown as a lowercase variable name with upper-case subscript, like $i_\mathrm{DS}$.
 * An upper-case variable name with a lower-case subscript is used to denote **RMS quantities**, like $I_\mathrm{ds}$.
+
+One deviation from this scheme is worth pointing out up front, as it is used throughout this material: in the small-signal derivations we write the signal *amplitudes* (phasors) as $\Vgs$, $\Vds$, $\Id$, i.e. with an upper-case variable name. Wherever an RMS value is meant, this is stated explicitly in the variable name, as in $V_\mathrm{n,rms}$.
 :::
 
 ::: {.callout-note title="A Comment on Active and Passive Devices and Linear vs. Nonlinear"}
@@ -137,8 +139,10 @@ $$
 The drain current dependency on the source-bulk voltage (the so-called "body effect") is introduced by the current source $\gmb \Vsb$:
 
 $$
-\gmb = \frac{\partial \ID(\VGS, \VDS, \VSB)}{\partial \VSB}
+\gmb = -\frac{\partial \ID(\VGS, \VDS, \VSB)}{\partial \VSB} = \frac{\partial \ID(\VGS, \VDS, V_\mathrm{BS})}{\partial V_\mathrm{BS}}
 $$
+
+Note the minus sign: raising the source potential above the bulk increases $\Vth$ and thus *lowers* $\ID$. By referencing $\gmb$ to $V_\mathrm{BS} = -\VSB$ it comes out **positive**, just like $\gm$, which is the common convention; typically $\gmb / \gm \approx 0.1 \ldots 0.3$. This is why the $\gmb \Vsb$ source in @fig-mosfet-small-signal-model is drawn with its arrow pointing *opposite* to the $\gm \Vgs$ source.
 
 
 {{< include /content/first_steps/_fig_mosfet_small_signal_model.qmd >}}
@@ -197,7 +201,7 @@ Please try to execute the following steps and answer the following questions:
    1. What is the difference in $\gm$, $\gds$, and other parameters between the NMOS and the PMOS? Why could they be different?
 :::
 
-::: {.callout-note title="Maxwell Capacitance Matrix" #nte-maxwell-cap-matrix}
+::: {#nte-maxwell-cap-matrix .callout-note title="Maxwell Capacitance Matrix"}
 A Maxwell capacitance matrix [@Maxwell_1873] provides the relation between voltages on a set of conductors and the charges on these conductors. For a given conductor set with $N$ conductors (and thus $N$ terminals) the relation is
 $$
 \mathbf{Q} = \mathbf{C} \cdot \mathbf{V}
@@ -207,10 +211,10 @@ $$
 \mathbf{C} =
 \begin{pmatrix}
 C_{11} + C_{12} & -C_{12} \\
--C_{21} & C_{21} + C_{22} \\
+-C_{12} & C_{12} + C_{22} \\
 \end{pmatrix}
 $$
-where $C_{xx} = \partial Q_x / \partial V_x$ is the auto capacitance from a conductor $x$ towards infinity (ground), and $C_{xy} = \partial Q_x / \partial V_y$ is the mutual capacitance from node/conductor $x$ to node/conductor $y$. For a physical capacitor $C_{xy} = C_{yx}$.
+where $C_{11}$ and $C_{22}$ are the **auto capacitances** of the conductors towards infinity (ground), and $C_{12} = C_{21}$ is the **mutual capacitance** between the two conductors. Note that these are the *physical* capacitances, and that they are therefore **not** identical to the entries of $\mathbf{C}$: a diagonal entry of $\mathbf{C}$ is the sum of all capacitances touching a node ($\partial Q_1 / \partial V_1 = C_{11} + C_{12}$), whereas an off-diagonal entry is *negative* ($\partial Q_1 / \partial V_2 = -C_{12}$).
 
 Using the above equation to calculate $Q_1$ (the charge on conductor $1$) results in
 $$
@@ -227,7 +231,9 @@ or
 $$
 \CGG = \frac{\partial Q_\mathrm{G}}{\partial V_\mathrm{G}}
 $$
-with $Q_\mathrm{G}$ the charge at terminal G in response to either $V_\mathrm{D}$ or $V_\mathrm{G}$. Note that in a MOSFET, generally $C_{xy} \ne C_{yx}$! 
+with $Q_\mathrm{G}$ the charge at terminal G in response to either $V_\mathrm{D}$ or $V_\mathrm{G}$. Note that in a MOSFET, generally $C_{xy} \ne C_{yx}$!
+
+This also explains the negative capacitance values that a simulator sometimes reports (see the exercise above): the off-diagonal entries of a Maxwell capacitance matrix carry a negative sign by construction, so a reported $\CGD$ of, e.g., $-1\,\text{fF}$ simply means a physical coupling capacitance of $1\,\text{fF}$ between gate and drain.
 :::
 
 ## Conclusion

--- a/content/first_steps/_sec_first_steps.qmd
+++ b/content/first_steps/_sec_first_steps.qmd
@@ -74,9 +74,7 @@ Throughout this material, we will largely stick to the following notation standa
 * Double-subscripts denote **dc sources**, like $\VDD$ and $\VSS$.
 * An **ac (small-signal) quantity** (incremental quantity) has a lower-case variable name with a lower-case subscript, like $\gm$.
 * A **total quantity** (dc plus ac) is shown as a lowercase variable name with upper-case subscript, like $i_\mathrm{DS}$.
-* An upper-case variable name with a lower-case subscript is used to denote **RMS quantities**, like $I_\mathrm{ds}$.
-
-One deviation from this scheme is worth pointing out up front, as it is used throughout this material: in the small-signal derivations we write the signal *amplitudes* (phasors) as $\Vgs$, $\Vds$, $\Id$, i.e. with an upper-case variable name. Wherever an RMS value is meant, this is stated explicitly in the variable name, as in $V_\mathrm{n,rms}$.
+* An upper-case variable name with a lower-case subscript is used to denote signal *amplitudes* (phasors), like $\Vgs$, $\Vds$, $\Id$.
 :::
 
 ::: {.callout-note title="A Comment on Active and Passive Devices and Linear vs. Nonlinear"}

--- a/content/ota_basic/_sec_basic_ota.qmd
+++ b/content/ota_basic/_sec_basic_ota.qmd
@@ -92,6 +92,8 @@ $$
 T_\mathrm{slew} \approx \frac{C_\mathrm{load} \cdot V_\mathrm{out,max}}{I_\mathrm{tail}} = \frac{50 \cdot 10^{-15} \cdot 0.9}{10 \cdot 10^{-6}} = 4.5\,\text{ns}.
 $$
 
+Note that we have optimistically inserted the *total* supply current budget of $10\,\mu\text{A}$ for $I_\mathrm{tail}$ here; the actual tail current will be smaller, since the bias branch $M_6$ also draws current. This is fine for a first sanity check, as it tells us the slewing contribution is negligible even if the real value turns out several times larger.
+
 This leaves plenty of margin for additional small-signal settling due to the limited bandwidth, as well as for reducing the supply current.
 
 The small-signal settling (assuming one pole at the bandwidth corner frequency) leads to an approximate settling time (1% error corresponds to $\approx 5 \tau$) of
@@ -128,7 +130,7 @@ In order to derive the governing small-signal equations for the OTA we will make
 - We will set $\gmb = 0$ for all MOSFETs.
 - We will further set $\Cgd = 0$ for all MOSFETs except for $M_4$ where we expect a Miller effect on this capacitor, and we could add its effect by increasing the capacitance at the gate node of $M_{3,4}$ (for background please see @sec-miller-theorem). However, as this does not create a dominant pole in this circuit, we consider this a minor effect (see @eq-simple-ota-gain). Thus, only $2\Cgs[3,4]$ is considered at the gate node of the current mirror load.
 - We assume $\gm \gg \gds$, so we set $\gds[1] = \gds[3] = 0$ as this node is dominated by $\gm[3]^{-1}$.
-- The drain capacitance of $M_2$ and $M_4$, as well as the gate capacitance of $M_2$, we could add to the load capacitance $C_\mathrm{load}$ (see @fig-basic-ota-dcop).
+- The drain capacitance of $M_2$ and $M_4$, as well as the gate capacitance of $M_2$, we could add to the load capacitance $C_\mathrm{load}$ (see @fig-basic-ota-dcop). Do not dismiss this as a second-order correction: with the small $C_\mathrm{load} = 50\,\text{fF}$ specified here, the sizing procedure will show that these device parasitics contribute roughly as much again as the specified load itself, so they effectively halve the achievable bandwidth if ignored.
 
 The resulting small-signal equivalent circuit is shown in @fig-basic-ota-small-signal.
 
@@ -165,17 +167,31 @@ $$
 A(s \to 0) = A_0 = \frac{\gm[1,2]}{\gds[2] + \gds[4]}
 $$ {#eq-simple-ota-gain-dc}
 
-which is plausible, and confirms the requirement of a high impedance at the output node. For very large frequencies we get
+which is plausible, and confirms the requirement of a high impedance at the output node.
+
+Above the dominant pole, but still well below the current-mirror doublet, the numerator of @eq-simple-ota-gain is still dominated by the term $2 \gm[3,4]$, and the gain becomes
 
 $$
-A (s \gg) = \frac{\gm[1,2]}{2 \cdot s C_\mathrm{load}}
+A(s) \approx \frac{\gm[1,2]}{2} \frac{2 \gm[3,4]}{\gm[3,4] \cdot s C_\mathrm{load}} = \frac{\gm[1,2]}{s C_\mathrm{load}}
+$$ {#eq-simple-ota-midband}
+
+which is essentially the behavior of an integrator. This is the frequency range in which the amplifier is actually operated, so we use @eq-simple-ota-midband to calculate the frequency where the gain drops to $|A(s_\mathrm{ug})| = 1 = \gm[1,2] / | j \omega_\mathrm{ug} C_\mathrm{load}|$:
+
+$$
+f_\mathrm{ug} = \frac{\gm[1,2]}{2 \pi C_\mathrm{load}}
+$$ {#eq-simple-ota-ug}
+
+Note that this is exactly the dc gain @eq-simple-ota-gain-dc multiplied by the dominant-pole frequency @eq-basic-ota-dominant-pole, i.e. the gain-bandwidth product, as it has to be for a system that behaves like a single-pole system up to $f_\mathrm{ug}$. The output conductances cancel, so the achievable GBW is set by $\gm[1,2]$ and $C_\mathrm{load}$ alone.
+
+::: {.callout-note title="Watch the Asymptote You Use"}
+It is tempting to obtain $f_\mathrm{ug}$ from the asymptote of @eq-simple-ota-gain for $s \to \infty$, where both numerator and denominator are dominated by their $s \Cgs[3,4]$ terms:
+
+$$
+A(s \to \infty) = \frac{\gm[1,2]}{2 \cdot s C_\mathrm{load}}
 $$ {#eq-simple-ota-highf}
 
-which is essentially the behavior of an integrator, and we can use @eq-simple-ota-highf to calculate the frequency where the gain drops to $|A(s_\mathrm{ug})| = 1 = \gm[1,2]/|2 j \omega_\mathrm{ug} C_\mathrm{load}|$:
-
-$$
-f_\mathrm{ug} = \frac{\gm[1,2]}{4 \pi C_\mathrm{load}}
-$$
+This differs from @eq-simple-ota-midband by a factor of two, and would predict a unity-gain frequency only half as large. The reason for the discrepancy is physical: @eq-simple-ota-highf describes the behavior *above* the doublet, where $\Cgs[3,4]$ shorts out the current mirror so that the signal path through $M_{3,4}$ is lost and only the direct path through $M_2$ remains --- hence half the transconductance. In a sensible design the doublet sits far above $f_\mathrm{ug}$, so @eq-simple-ota-midband is the asymptote to use.
+:::
 
 Looking at @eq-simple-ota-gain, we see that we have a dominant pole at $s_\mathrm{p}$ and a pole-zero doublet with $s_\mathrm{pd}$/$s_\mathrm{zd}$:
 $$
@@ -308,7 +324,7 @@ $$ {#eq-mosfet-mismatch-kp}
 
 The resulting standard deviation of the input offset voltage $V_\mathrm{offs}$ of a differential pair with small $\gmid$ is then given by [@Razavi_Analog_CMOS]
 $$
-V_\mathrm{offs} = \sqrt{\left( \frac{\VGS - \Vth}{2} \right)^2 \cdot \var[\frac{\Delta (W/L)}{{(W/L)}}] + \var[\Delta \Vth]}.
+\sdev[V_\mathrm{offs}] = \sqrt{\left( \frac{\VGS - \Vth}{2} \right)^2 \cdot \var[\frac{\Delta (W/L)}{{(W/L)}}] + \var[\Delta \Vth]}.
 $$ {#eq-diffpair-offset}
 
 The mismatch in the drain current of two current-mirror transistors, characterized as the standard deviation and for small $\gmid$, is given by [@Razavi_Analog_CMOS]
@@ -317,7 +333,7 @@ $$
 \var[\frac{\Delta \ID}{\ID}] = \var[\frac{\Delta (W/L)}{(W/L)}] + 4 \cdot \var[\frac{\Delta \Vth}{\VGS - \Vth}].
 $$ {#eq-currentmirror-offset}
 
-To minimize the input offset voltage in a differential pair we should strive to minimize $\VGS$ (i.e., to maximize $\gmid$, see @eq-diffpair-offset) and to minimize the mismatch in current mirrors we should target a large $\VGS$ (i.e., to minimize $\gmid$, see @eq-currentmirror-offset). In both cases the MOSFET area $W \cdot L$ needs to be large enough (see @eq-mosfet-mismatch-vth and @eq-mosfet-mismatch-kp).
+To minimize the input offset voltage in a differential pair we should strive to minimize the overdrive voltage $\VGS - \Vth$ (i.e., to maximize $\gmid$, see @eq-diffpair-offset) and to minimize the mismatch in current mirrors we should target a large overdrive voltage (i.e., to minimize $\gmid$, see @eq-currentmirror-offset). In both cases the MOSFET area $W \cdot L$ needs to be large enough (see @eq-mosfet-mismatch-vth and @eq-mosfet-mismatch-kp).
 :::
 
 How can we now cope with mismatch in design and simulation? We can account for the transistor mismatch according to @eq-mosfet-mismatch-vth and @eq-mosfet-mismatch-kp in circuit analysis and quantify its effect. We can then take this into account when performing the circuit sizing procedure.
@@ -399,11 +415,11 @@ After a successful run, a documentation is automatically generated. The result o
 
 ### PVT Simulation Analysis
 
-Looking at the CACE report in @nte-basic-ota-cace-result, we see that (luckily) the specification is met for all parameters. This is great news! We now have a design that we carefully simulated across PVT and other corners and that is ready for layout. Once we have the layout ready, we can extract the wiring parasitics ($R$ and $C$) as well as other layout-dependent effects like [well proximity](https://global.oup.com/us/companion.websites/9780195170153/pdf/proximityeffectmodels.pdf). Using this augmented netlist, we can then again use CACE to check performance across conditions and parameter variations, and if we still pass all specification points, then our design is finished.
+Looking at the CACE report in @nte-basic-ota-cace-result, we see that (luckily) the specification is met across all **PVT corners**. This is great news! We now have a design that we carefully simulated across PVT and other corners and that is ready for layout. Once we have the layout ready, we can extract the wiring parasitics ($R$ and $C$) as well as other layout-dependent effects like [well proximity](https://global.oup.com/us/companion.websites/9780195170153/pdf/proximityeffectmodels.pdf). Using this augmented netlist, we can then again use CACE to check performance across conditions and parameter variations, and if we still pass all specification points, then our design is finished.
 
 ### Monte Carlo Simulation Analysis
 
-Looking at the CACE report in @nte-basic-ota-cace-result, we see that the output voltage specification is not met due to MOSFET mismatch! We have not considered transistor mismatch in the circuit sizing procedure, and as a result the selected MOSFET dimensions prove to be too small. We should now go back and change the transistor sizing (increasing $L$ significantly while keeping the $\gmid$ values). Likely we will find that some performance parameters are now deteriorating due to the increased MOSFET dimensions, and we need to iterate until all performance metrics are met in the presence of transistor mismatch.
+The **Monte Carlo** run in the same CACE report in @nte-basic-ota-cace-result tells a different story: here the output voltage specification is not met, due to MOSFET mismatch! Note that this is not a contradiction to the PVT result above --- PVT corners shift all devices together, whereas mismatch makes nominally identical devices differ, and it is exactly this asymmetry that the voltage buffer is sensitive to. We have not considered transistor mismatch in the circuit sizing procedure, and as a result the selected MOSFET dimensions prove to be too small. We should now go back and change the transistor sizing (increasing $L$ significantly while keeping the $\gmid$ values). Likely we will find that some performance parameters are now deteriorating due to the increased MOSFET dimensions, and we need to iterate until all performance metrics are met in the presence of transistor mismatch.
 
 It is not unusual that the power consumption now increases, as we have to increase the size of the MOSFETs for matching, and these larger MOSFETs increase the parasitic capacitances which in turn lead to larger power consumption to keep the required bandwidth by increasing the $\gm$.
 
@@ -421,7 +437,7 @@ Being a single-stage amplifier stability is usually not an issue, as only the ou
 
 {{< include /content/ota_basic/_fig_ota_se_r2r.qmd >}}
 
-Another popular version is shown in @fig-ota-se-twostage. Here, we have a two-stage amplifier able to provide higher voltage gain. The first stage (the diffpair loaded by a current mirror) is followed by a single-stage common-source amplifier with current-source load. Being a two-stage amplifier with two high-ohmic nodes, stability is a concern, so usually we need some form of compensation. @fig-ota-se-twostage shows a very simplistic Miller-compensation (see @sec-miller-compensation) using $C_\mathrm{M}$. Often, we would want to implement a more advanced scheme. Some examples can be found in [@Baker_compensating_OPAMP]. An interesting technique is the indirect compensation with cascoded input differential pairs (see @fig-improved-ota) for higher power supply rejection. An advantage of this two-stage amplifier (compared with the simple 5T-OTA) is the dc-balanced load on top of the differential pair, as each side sees a voltage drop from $\VDD$ of one $\VGS$ ($\VGS[3]$ on the left side and $\VGS[5]$ on the right side).
+Another popular version is shown in @fig-ota-se-twostage. Here, we have a two-stage amplifier able to provide higher voltage gain. The first stage (the diffpair loaded by a current mirror) is followed by a single-stage common-source amplifier with current-source load. Being a two-stage amplifier with two high-ohmic nodes, stability is a concern, so usually we need some form of compensation. @fig-ota-se-twostage shows a very simplistic Miller-compensation (see @sec-miller-compensation) using $C_\mathrm{M}$. Often, we would want to implement a more advanced scheme. Some examples can be found in [@Baker_compensating_OPAMP]. An interesting technique is the indirect compensation with cascoded input differential pairs (see @fig-improved-ota) for higher power supply rejection. An advantage of this two-stage amplifier (compared with the simple 5T-OTA) is that both output nodes of the input stage are dc-balanced: each of them sits one $\VGS$ below $\VDD$ --- on the left set by the diode-connected $\VGS[3]$, on the right set by the gate of the second-stage device $M_5$, i.e. by $\VGS[5]$. In the plain 5T-OTA the right-hand node is instead the output node, whose dc level is imposed by the external feedback, so the two sides of the differential pair are generally *not* balanced.
 
 {{< include /content/ota_basic/_fig_ota_se_twostage.qmd >}}
 

--- a/content/ota_diff/_sec_differential_ota.qmd
+++ b/content/ota_diff/_sec_differential_ota.qmd
@@ -24,7 +24,7 @@ The OTA presented in @sec-ota-variants-single-ended can be readily adapted for d
 
 This OTA shows a load on top of the differential pair that we have not yet studied. It is instructive to analyze this structure in terms of differential and common-mode operation.
 
-For common-mode operation (i.e., injecting the same current into the drain of $M_3$ and $M_4$) we have the same voltage at the drains of $M_{3,5}$, thus $\VDS[3]=\VDS[5]$. We have thus no current flowing through $R_{1,2}$ and as a result $\VDS[3]=\VDS[5] = V_\mathrm{X} = \VGS[3] = \VGS[5] = \VGS[3,5]$. We realize that $M_3$ and $M_5$ are diode-connected for common-mode operation. We thus have well-defined dc operating points, and also low common-mode gain, since the common-mode load is $\gm[3]^{-1} \parallel \gm[5]^{-1}$.
+For common-mode operation (i.e., injecting the same current into the drain of $M_3$ and $M_4$) we have the same voltage at the drains of $M_{3,5}$, thus $\VDS[3]=\VDS[5]$. We have thus no current flowing through $R_{1,2}$ and as a result $\VDS[3]=\VDS[5] = V_\mathrm{X} = \VGS[3] = \VGS[5] = \VGS[3,5]$. We realize that $M_3$ and $M_5$ are diode-connected for common-mode operation. We thus have well-defined dc operating points, and also low common-mode gain, since each side of the circuit is then loaded by its own diode-connected transistor, i.e. the common-mode load per half circuit is $\gm[3,5]^{-1}$ (no current flows through $R_{1,2}$, so the resistors play no role here).
 
 For pure differential operation, the mid-point $X$ of $R_{1,2}$ acts as a virtual ground. The bias voltage $\VGS[3,5]$ is thus not changed (it is set only by the common-mode operation) and thus $M_3$ and $M_5$ operate as current sources. The differential load impedance is high and is given by $R_\mathrm{load} = (R_1 + R_2) \parallel (\gds[3]^{-1} + \gds[5]^{-1})$.
 
@@ -34,7 +34,7 @@ For differential operation, the differential pair of $M_{1,2}$ is loaded by $R_\
 
 As soon as we implement a two-stage amplifier we need to look into stability. We likely have more than two poles, and in the case of the amplifier in @fig-diff-ota-resload we have a low-frequency pole at the drains of $M_{1,3}$ and $M_{2,5}$ and a further low-frequency pole at the output. Any additional pole will add further phase shift making stability critical. We now need a method to stabilize this amplifier and thus we will look into *Miller compensation*.
 
-Of course, loop gain analysis of differential OTAs can and should be carried out. An exemplary testbench where the loop gain is simulated with Rosenstark's, Middlebrook's, and Tian's method can be found [here](xschem/ota-differential_tb-loopgain.sch). Note that there is no underlying circuit right now and it should only show how it could be done.
+Of course, loop gain analysis of differential OTAs can and should be carried out. Exemplary testbenches where the loop gain is simulated with Middlebrook's and Tian's method can be found for the [5T-OTA](./xschem/ota-5t_tb-loopgain.sch) and for the [improved OTA](./xschem/ota-improved_tb-loopgain.sch); the same approach carries over to the differential case, where the loop has to be broken in both the differential and the common-mode path.
 
 ## Miller Compensation {#sec-miller-compensation}
 
@@ -203,11 +203,11 @@ Keep the technique shown in @fig-diff-ota-resload-miller-cm (using $R_{3,4}$ and
 
 When designing the OTA with the above-mentioned techniques like Miller compensation and the common-mode setting, we find that we have issues with common-mode stability. There is one issue not obvious at first sight with the MOSFET-R load of the first stage: At the node $X$ there is significant capacitance due to the gates of $M_{3,5}$. This capacitance forms a low-pass response with the resistance of $R_{1,2}$ and thus creates a low-frequency pole. This pole is in the common-mode path, and leads to a zero for the common-mode gain.
 
-In other words: At low frequencies, the common-mode gain is given by @eq-diff-ota-cmgain, but at higher frequencies (above the pole at node $X$), the common-mode gain increases significantly as the load resistance of the first stage increases from $\gm[3]^{-1} \parallel \gm[5]^{-1}$ to $\gds[3]^{-1} \parallel \gds[5]^{-1}$. We need to counteract this effect by adding a capacitor in parallel to $R_{1,2}$, as shown in @fig-diff-ota-final. We use the opportunity to also add a series resistor to this capacitor to introduce an additional zero to improve phase margin.
+In other words: At low frequencies, the common-mode gain is given by @eq-diff-ota-cmgain, but at higher frequencies (above the pole at node $X$) the gates of $M_{3,5}$ can no longer follow the drains, so these transistors stop acting as diodes and behave as current sources instead. The common-mode load of a half circuit consequently increases from $\gm[3,5]^{-1}$ to $R_{1,2} \parallel \gds[3,5]^{-1}$, and the common-mode gain increases significantly. We need to counteract this effect by adding a capacitor in parallel to $R_{1,2}$, as shown in @fig-diff-ota-final. We use the opportunity to also add a series resistor to this capacitor to introduce an additional zero to improve phase margin.
 
 {{< include /content/ota_diff/_fig_ota_diff_twostage_final.qmd >}}
 
-You can find the sizing script for the differential OTA [here](./gmid/sizing_diff_ota.ipynb), as well as the circuit-level design in Xschem [here](./xschem/ota-diff.sch). The testbench for differential and common-mode gain analysis can be found [here](./xschem/ota-diff_tb-acol.sch).
+This OTA is sized for a considerably more demanding target than the voltage buffer of @sec-basic-ota, namely a gain-bandwidth product of $\text{GBW} = 1\,\text{GHz}$. You can find the sizing script for the differential OTA [here](./gmid/sizing_diff_ota.ipynb), as well as the circuit-level design in Xschem [here](./xschem/ota-diff.sch). The testbench for differential and common-mode gain analysis can be found [here](./xschem/ota-diff_tb-acol.sch).
 
 The final Xschem schematics of the differential OTA and the testbench are also shown in the figures below.
 


### PR DESCRIPTION
## What changed

Didactic corrections and clarifications in four chapters:

- **MOSFET diode:** The discussion of feedback and bandwidth now cleanly separates two quantities that were previously conflated: the closed-loop −3 dB bandwidth (which shows that the **gain-bandwidth product is preserved** under frequency-independent feedback) and the closed-loop unity-gain frequency $f_\mathrm{T,cl} = f_\mathrm{T,ol}\sqrt{1-G^2}$. The distinction matters for the MOSFET diode, where $G = 1$ applies.
- **First steps:** States the phasor-amplitude notation deviation explicitly; fixes the sign of the $g_\mathrm{mb}$ definition (referenced to $V_\mathrm{BS}$ so it comes out positive, like $g_\mathrm{m}$) and explains the opposing arrow in the small-signal model; corrects the Maxwell capacitance matrix ($C_{12} = C_{21}$ as the physical mutual capacitance, with the diagonal/off-diagonal structure explained) and adds why simulators report negative capacitances.
- **Basic OTA:** The unity-gain frequency is now derived from the correct mid-band asymptote, giving $f_\mathrm{ug} = g_\mathrm{m1,2}/(2\pi C_\mathrm{load})$ — the previous $s \to \infty$ asymptote is 2× lower because it describes the region above the current-mirror doublet, explained in a new callout. Also: the slewing estimate's tail-current approximation is stated, a warning that device parasitics rival the specified 50 fF load, the offset equation is written as a standard deviation, mismatch guidance now refers to the overdrive voltage, and the two-stage dc-balance argument is corrected.
- **Differential OTA:** The common-mode load is corrected to $g_\mathrm{m3,5}^{-1}$ per half circuit ($R_{1,2}$ carry no common-mode current), the high-frequency common-mode load to $R_{1,2} \parallel g_\mathrm{ds3,5}^{-1}$, the loop-gain testbench links now point at the existing 5T/improved-OTA schematics instead of a placeholder, and the 1 GHz GBW design target is stated.

## Why

These passages either had sign/factor errors (gmb definition, $f_\mathrm{ug}$ factor of two, Maxwell matrix indices) or were misleading in ways students stumble over (GBWP vs. closed-loop $f_\mathrm{T}$, PVT vs. Monte-Carlo interpretation, common-mode load of the MOSFET-R first stage).

## Notes for review

- Referenced files were verified to exist (`ota-5t_tb-loopgain.sch`, `ota-improved_tb-loopgain.sch`) and the `\sdev` macro is defined in `content/_abbrv.qmd`.
- Prose only; no figure code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)